### PR TITLE
댓글 관련 기능 추가

### DIFF
--- a/space-d/src/docs/asciidoc/index.adoc
+++ b/space-d/src/docs/asciidoc/index.adoc
@@ -258,3 +258,13 @@ include::{snippets}/docs-controller-test/exceptions/exception-response-fields-up
 === 댓글 목록 조회 API
 
 operation::comment-controller-test/read-all-by_성공_테스트[snippets='http-request,request-headers,path-parameters,http-response,response-fields']
+
+[[Like-API]]
+== Like API
+
+[[Process-Like]]
+=== 좋아요 API
+
+operation::like-controller-test/process-like_성공_테스트[snippets='http-request,request-headers,path-parameters,http-response']
+
+include::{snippets}/docs-controller-test/exceptions/exception-response-fields-processLikeException.adoc[]

--- a/space-d/src/docs/asciidoc/index.adoc
+++ b/space-d/src/docs/asciidoc/index.adoc
@@ -229,3 +229,32 @@ operation::word-controller-test/search_성공_테스트[snippets='http-request,q
 === 많이 조회한 용어 목록 조회 API
 
 operation::word-controller-test/read-popular-words-all_성공_테스트[snippets='http-request,http-response,response-fields']
+
+[[Comment-API]]
+== Comment API
+
+[[Save-Comment]]
+=== 댓글 추가 API
+
+operation::comment-controller-test/save_성공_테스트[snippets='http-request,request-headers,path-parameters,request-fields,http-response']
+
+include::{snippets}/docs-controller-test/exceptions/exception-response-fields-saveCommentException.adoc[]
+
+[[Delete-Comment]]
+=== 댓글 삭제 API
+
+operation::comment-controller-test/delete_성공_테스트[snippets='http-request,request-headers,path-parameters,http-response']
+
+include::{snippets}/docs-controller-test/exceptions/exception-response-fields-deleteCommentException.adoc[]
+
+[[Update-Comment]]
+=== 댓글 수정 API
+
+operation::comment-controller-test/update_성공_테스트[snippets='http-request,request-headers,path-parameters,request-fields,http-response']
+
+include::{snippets}/docs-controller-test/exceptions/exception-response-fields-updateCommentException.adoc[]
+
+[[Read-All-Comments]]
+=== 댓글 목록 조회 API
+
+operation::comment-controller-test/read-all-by_성공_테스트[snippets='http-request,request-headers,path-parameters,http-response,response-fields']

--- a/space-d/src/main/java/com/dnd/spaced/core/account/domain/Account.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/account/domain/Account.java
@@ -67,6 +67,10 @@ public class Account extends CreateTimeEntity implements Persistable<String> {
         this.profileInfo.changeProfileInfo(changedNickname, changedProfileImage);
     }
 
+    public boolean isEqualTo(String id) {
+        return this.id.equals(id);
+    }
+
     private boolean isInvalidId(String id) {
         return id == null || id.isBlank();
     }

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/application/CommentService.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/application/CommentService.java
@@ -1,0 +1,108 @@
+package com.dnd.spaced.core.comment.application;
+
+import com.dnd.spaced.core.account.domain.Account;
+import com.dnd.spaced.core.account.domain.repository.AccountRepository;
+import com.dnd.spaced.core.comment.application.dto.response.ReadAllCommentDto;
+import com.dnd.spaced.core.comment.application.exception.AssociationAccountNotFoundException;
+import com.dnd.spaced.core.comment.application.exception.AssociationWordNotFoundException;
+import com.dnd.spaced.core.comment.application.exception.CommentNotFoundException;
+import com.dnd.spaced.core.comment.application.exception.ForbiddenCommentException;
+import com.dnd.spaced.core.comment.domain.Comment;
+import com.dnd.spaced.core.comment.domain.repository.CommentRepository;
+import com.dnd.spaced.core.like.domain.repository.LikeCountRepository;
+import com.dnd.spaced.core.comment.domain.repository.dto.request.CommentPageRequest;
+import com.dnd.spaced.core.comment.domain.repository.dto.response.LikedCommentDto;
+import com.dnd.spaced.core.word.domain.Word;
+import com.dnd.spaced.core.word.domain.repository.WordRepository;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CommentService {
+
+    private static final String NOT_AUTHENTICATION_ACCOUNT = "notAuthenticationAccount";
+
+    private final WordRepository wordRepository;
+    private final AccountRepository accountRepository;
+    private final CommentRepository commentRepository;
+    private final LikeCountRepository likeCountRepository;
+
+    @Transactional
+    public void save(String accountId, Long wordId, String content) {
+        Account writer = findAccount(accountId);
+        Word word = findWord(wordId);
+        Comment comment = new Comment(writer.getId(), word.getId(), content);
+
+        commentRepository.save(comment);
+    }
+
+    @Transactional
+    public void delete(String accountId, Long commentId) {
+        Account owner = findAccount(accountId);
+        Comment comment = findComment(commentId);
+
+        if (!comment.isOwner(owner)) {
+            throw new ForbiddenCommentException("댓글을 삭제할 권한이 없습니다.");
+        }
+
+        commentRepository.delete(comment);
+    }
+
+    @Transactional
+    public void update(String accountId, Long commentId, String content) {
+        Account owner = findAccount(accountId);
+        Comment comment = findComment(commentId);
+
+        if (!comment.isOwner(owner)) {
+            throw new ForbiddenCommentException("댓글을 수정할 권한이 없습니다.");
+        }
+
+        comment.changeContent(content);
+    }
+
+    public List<ReadAllCommentDto> readAllBy(String accountId, Long wordId, Long lastCommentId, Pageable pageable) {
+        CommentPageRequest commentPageRequest = new CommentPageRequest(pageable, lastCommentId);
+        List<LikedCommentDto> result = commentRepository.findAllBy(
+                calculateLikeAccountId(accountId),
+                wordId,
+                commentPageRequest
+        );
+        List<Object> commentIds = result.stream()
+                                        .map(dto -> (Object) dto.comment().getId())
+                                        .toList();
+        Map<Long, Integer> cacheLikeCount = likeCountRepository.findLikeCountAllBy(wordId, commentIds);
+
+        return result.stream()
+                     .map(dto -> ReadAllCommentDto.of(dto, cacheLikeCount))
+                     .toList();
+    }
+
+    private Account findAccount(String accountId) {
+        return accountRepository.findBy(accountId)
+                                .orElseThrow(() -> new AssociationAccountNotFoundException("유효하지 않은 회원입니다."));
+    }
+
+    private Word findWord(Long wordId) {
+        return wordRepository.findBy(wordId)
+                             .orElseThrow(() -> new AssociationWordNotFoundException("댓글과 관련된 용어를 찾을 수 없습니다."));
+    }
+
+    private Comment findComment(Long commentId) {
+        return commentRepository.findBy(commentId)
+                                .orElseThrow(() -> new CommentNotFoundException("지정한 ID에 해당하는 댓글이 없습니다."));
+    }
+
+    private String calculateLikeAccountId(String accountId) {
+        if (accountId == null) {
+            return NOT_AUTHENTICATION_ACCOUNT;
+        }
+
+        return accountId;
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/application/dto/response/ReadAllCommentDto.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/application/dto/response/ReadAllCommentDto.java
@@ -1,0 +1,45 @@
+package com.dnd.spaced.core.comment.application.dto.response;
+
+import com.dnd.spaced.core.comment.domain.Comment;
+import com.dnd.spaced.core.comment.domain.repository.dto.response.LikedCommentDto;
+import java.util.Map;
+
+public record ReadAllCommentDto(CommentInfoDto commentInfo, WriterInfoDto writerInfo, boolean isLike) {
+
+    public record CommentInfoDto(Long id, Long wordId, String content, int likeCount) {
+    }
+
+    public record WriterInfoDto(String id, String writerNickname, String writerProfileImage) {
+    }
+
+    public static ReadAllCommentDto of(LikedCommentDto dto, Map<Long, Integer> cacheLikeCount) {
+        Comment comment = dto.comment();
+        WriterInfoDto writerInfoDto = new WriterInfoDto(
+                comment.getAccountId(),
+                dto.writerNickname(),
+                dto.writerProfileImage()
+        );
+        CommentInfoDto commentInfoDto = new CommentInfoDto(
+                comment.getId(),
+                comment.getWordId(),
+                comment.getContent(),
+                calculateLikeCount(
+                        cacheLikeCount.compute(
+                                comment.getId(),
+                                (key, value) -> value == null ? comment.getLikeCount() : value
+                        ),
+                        dto.isLiked()
+                )
+        );
+
+        return new ReadAllCommentDto(commentInfoDto, writerInfoDto, dto.isLiked());
+    }
+
+    private static int calculateLikeCount(int likeCount, boolean isLiked) {
+        if (isLiked) {
+            return likeCount + 1;
+        }
+
+        return likeCount;
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/application/exception/AssociationAccountNotFoundException.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/application/exception/AssociationAccountNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dnd.spaced.core.comment.application.exception;
+
+import com.dnd.spaced.global.exception.base.CommentClientException;
+import com.dnd.spaced.global.exception.code.CommentErrorCode;
+
+public class AssociationAccountNotFoundException extends CommentClientException {
+
+    public AssociationAccountNotFoundException(String message) {
+        super(CommentErrorCode.ASSOCIATION_WORD_NOT_FOUND, message);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/application/exception/AssociationWordNotFoundException.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/application/exception/AssociationWordNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dnd.spaced.core.comment.application.exception;
+
+import com.dnd.spaced.global.exception.base.CommentClientException;
+import com.dnd.spaced.global.exception.code.CommentErrorCode;
+
+public class AssociationWordNotFoundException extends CommentClientException {
+
+    public AssociationWordNotFoundException(String message) {
+        super(CommentErrorCode.ASSOCIATION_WORD_NOT_FOUND, message);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/application/exception/CommentNotFoundException.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/application/exception/CommentNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dnd.spaced.core.comment.application.exception;
+
+import com.dnd.spaced.global.exception.base.CommentClientException;
+import com.dnd.spaced.global.exception.code.CommentErrorCode;
+
+public class CommentNotFoundException extends CommentClientException {
+
+    public CommentNotFoundException(String message) {
+        super(CommentErrorCode.COMMENT_NOT_FOUND, message);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/application/exception/ForbiddenCommentException.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/application/exception/ForbiddenCommentException.java
@@ -1,0 +1,11 @@
+package com.dnd.spaced.core.comment.application.exception;
+
+import com.dnd.spaced.global.exception.base.CommentClientException;
+import com.dnd.spaced.global.exception.code.CommentErrorCode;
+
+public class ForbiddenCommentException extends CommentClientException {
+
+    public ForbiddenCommentException(String message) {
+        super(CommentErrorCode.FORBIDDEN_COMMENT, message);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/domain/Comment.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/domain/Comment.java
@@ -1,0 +1,63 @@
+package com.dnd.spaced.core.comment.domain;
+
+import com.dnd.spaced.core.comment.domain.exception.InvalidCommentContentException;
+import com.dnd.spaced.global.audit.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "comments")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = false, of = "id")
+public class Comment extends BaseTimeEntity {
+
+    private static final int CONTENT_MIN_LENGTH = 1;
+    private static final int CONTENT_MAX_LENGTH = 100;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String accountId;
+
+    private Long wordId;
+
+    private String content;
+
+    private int likeCount = 0;
+
+    public Comment(String accountId, Long wordId, String content) {
+        if (isInvalidContent(content)) {
+            throw new InvalidCommentContentException("댓글 내용은 최소 1글자 이상, 최소 100글자 이하여야 합니다");
+        }
+
+        this.accountId = accountId;
+        this.wordId = wordId;
+        this.content = content;
+    }
+
+    private boolean isInvalidContent(String content) {
+        return content == null || content.isBlank()
+                || !(CONTENT_MIN_LENGTH <= content.length() && content.length() <= CONTENT_MAX_LENGTH);
+    }
+
+    public boolean isOwner(String accountId) {
+        return this.accountId.equals(accountId);
+    }
+
+    public void changeContent(String content) {
+        if (isInvalidContent(content)) {
+            throw new InvalidCommentContentException("댓글 내용은 최소 1글자 이상, 최소 100글자 이하여야 합니다");
+        }
+
+        this.content = content;
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/domain/Comment.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/domain/Comment.java
@@ -1,5 +1,6 @@
 package com.dnd.spaced.core.comment.domain;
 
+import com.dnd.spaced.core.account.domain.Account;
 import com.dnd.spaced.core.comment.domain.exception.InvalidCommentContentException;
 import com.dnd.spaced.global.audit.BaseTimeEntity;
 import jakarta.persistence.Entity;
@@ -49,8 +50,8 @@ public class Comment extends BaseTimeEntity {
                 || !(CONTENT_MIN_LENGTH <= content.length() && content.length() <= CONTENT_MAX_LENGTH);
     }
 
-    public boolean isOwner(String accountId) {
-        return this.accountId.equals(accountId);
+    public boolean isOwner(Account account) {
+        return account.isEqualTo(this.accountId);
     }
 
     public void changeContent(String content) {

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/domain/exception/InvalidCommentContentException.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/domain/exception/InvalidCommentContentException.java
@@ -1,0 +1,11 @@
+package com.dnd.spaced.core.comment.domain.exception;
+
+import com.dnd.spaced.global.exception.base.CommentClientException;
+import com.dnd.spaced.global.exception.code.CommentErrorCode;
+
+public class InvalidCommentContentException extends CommentClientException {
+
+    public InvalidCommentContentException(String message) {
+        super(CommentErrorCode.INVALID_COMMENT_CONTENT, message);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/domain/repository/CommentRepository.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/domain/repository/CommentRepository.java
@@ -1,0 +1,18 @@
+package com.dnd.spaced.core.comment.domain.repository;
+
+import com.dnd.spaced.core.comment.domain.Comment;
+import com.dnd.spaced.core.comment.domain.repository.dto.request.CommentPageRequest;
+import com.dnd.spaced.core.comment.domain.repository.dto.response.LikedCommentDto;
+import java.util.List;
+import java.util.Optional;
+
+public interface CommentRepository {
+
+    Comment save(Comment comment);
+
+    Optional<Comment> findBy(Long id);
+
+    List<LikedCommentDto> findAllBy(String accountId, Long wordId, CommentPageRequest pageRequest);
+
+    void delete(Comment comment);
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/domain/repository/dto/request/CommentPageRequest.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/domain/repository/dto/request/CommentPageRequest.java
@@ -1,0 +1,6 @@
+package com.dnd.spaced.core.comment.domain.repository.dto.request;
+
+import org.springframework.data.domain.Pageable;
+
+public record CommentPageRequest(Pageable pageable, Long lastCommentId) {
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/domain/repository/dto/response/LikedCommentDto.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/domain/repository/dto/response/LikedCommentDto.java
@@ -1,0 +1,6 @@
+package com.dnd.spaced.core.comment.domain.repository.dto.response;
+
+import com.dnd.spaced.core.comment.domain.Comment;
+
+public record LikedCommentDto(Comment comment, boolean isLiked, String writerNickname, String writerProfileImage) {
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/infrastructure/CommentCrudRepository.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/infrastructure/CommentCrudRepository.java
@@ -1,0 +1,7 @@
+package com.dnd.spaced.core.comment.infrastructure;
+
+import com.dnd.spaced.core.comment.domain.Comment;
+import org.springframework.data.repository.CrudRepository;
+
+interface CommentCrudRepository extends CrudRepository<Comment, Long> {
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/infrastructure/CommentQuerydslRepository.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/infrastructure/CommentQuerydslRepository.java
@@ -1,0 +1,100 @@
+package com.dnd.spaced.core.comment.infrastructure;
+
+import static com.dnd.spaced.core.account.domain.QAccount.account;
+import static com.dnd.spaced.core.comment.domain.QComment.comment;
+import static com.dnd.spaced.core.like.domain.QLike.like;
+
+import com.dnd.spaced.core.comment.domain.Comment;
+import com.dnd.spaced.core.comment.domain.repository.CommentRepository;
+import com.dnd.spaced.core.comment.domain.repository.dto.request.CommentPageRequest;
+import com.dnd.spaced.core.comment.domain.repository.dto.response.LikedCommentDto;
+import com.dnd.spaced.core.comment.infrastructure.util.CommentSortConditionConverter;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentQuerydslRepository implements CommentRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final CommentCrudRepository commentCrudRepository;
+
+    @Override
+    public Comment save(Comment comment) {
+        return commentCrudRepository.save(comment);
+    }
+
+    @Override
+    public Optional<Comment> findBy(Long id) {
+        return commentCrudRepository.findById(id);
+    }
+
+    @Override
+    public List<LikedCommentDto> findAllBy(String accountId, Long wordId, CommentPageRequest pageRequest) {
+        return queryFactory.select(
+                                   Projections.constructor(
+                                           LikedCommentDto.class,
+                                           comment,
+                                           like.id.isNotNull(),
+                                           account.profileInfo.nickname,
+                                           account.profileInfo.profileImage
+                                   )
+                           )
+                           .from(comment)
+                           .join(account).on(comment.accountId.eq(account.id))
+                           .leftJoin(like).on(comment.id.eq(like.commentId), like.accountId.eq(accountId))
+                           .where(comment.wordId.eq(wordId), calculateLastCommentIdBooleanExpression(pageRequest))
+                           .orderBy(
+                                   CommentSortConditionConverter.convert(pageRequest.pageable())
+                                                                .toArray(OrderSpecifier[]::new)
+                           )
+                           .limit(pageRequest.pageable().getPageSize())
+                           .fetch();
+    }
+
+    @Override
+    public void delete(Comment comment) {
+        commentCrudRepository.delete(comment);
+    }
+
+    private BooleanExpression calculateLastCommentIdBooleanExpression(CommentPageRequest pageRequest) {
+        if (pageRequest.lastCommentId() == null) {
+            return null;
+        }
+
+        if (isLastCommentIdGt(pageRequest.pageable())) {
+            return lastCommentIdGt(pageRequest.lastCommentId());
+        }
+
+        return lastCommentIdLt(pageRequest.lastCommentId());
+    }
+
+    private boolean isLastCommentIdGt(Pageable pageable) {
+        return pageable.getSort()
+                       .get()
+                       .anyMatch(order -> "id".equals(order.getProperty()) && order.isAscending());
+    }
+
+    private BooleanExpression lastCommentIdGt(Long id) {
+        if (id == null) {
+            return null;
+        }
+
+        return comment.id.gt(id);
+    }
+
+    private BooleanExpression lastCommentIdLt(Long id) {
+        if (id == null) {
+            return null;
+        }
+
+        return comment.id.lt(id);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/infrastructure/util/CommentSortConditionConverter.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/infrastructure/util/CommentSortConditionConverter.java
@@ -1,0 +1,69 @@
+package com.dnd.spaced.core.comment.infrastructure.util;
+
+import static com.dnd.spaced.core.comment.domain.QComment.comment;
+
+import com.dnd.spaced.global.repository.OrderByNull;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.Sort.Order;
+
+public enum CommentSortConditionConverter {
+    LIKE_COUNT("likeCount", List.of(comment.likeCount, comment.id)),
+    ID("id", List.of(comment.id));
+
+    private final String sortCondition;
+    private final List<ComparableExpressionBase<?>> expressions;
+
+    CommentSortConditionConverter(String sortCondition, List<ComparableExpressionBase<?>> expressions) {
+        this.sortCondition = sortCondition;
+        this.expressions = expressions;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<OrderSpecifier<?>> convert(Pageable pageable) {
+        return findOrder(pageable).map(order -> Arrays.stream(CommentSortConditionConverter.values())
+                                                      .filter(
+                                                              converter -> converter.sortCondition.equalsIgnoreCase(
+                                                                      order.getProperty()
+                                                              )
+                                                      )
+                                                      .findAny()
+                                                      .map(
+                                                              converter -> converter.convertOrderSpecifiers(
+                                                                      order.getDirection()
+                                                              )
+                                                      )
+                                                      .orElse(List.of(OrderByNull.DEFAULT)))
+                                  .orElse(List.of(OrderByNull.DEFAULT));
+    }
+
+    private static Optional<Order> findOrder(Pageable pageable) {
+        return pageable.getSort()
+                       .get()
+                       .findAny();
+    }
+
+    private List<OrderSpecifier<?>> convertOrderSpecifiers(Direction direction) {
+        List<OrderSpecifier<?>> result = new ArrayList<>();
+
+        for (ComparableExpressionBase<?> expression : this.expressions) {
+            result.add(applyDirection(expression, direction));
+        }
+
+        return result;
+    }
+
+    private OrderSpecifier<?> applyDirection(ComparableExpressionBase<?> expression, Direction direction) {
+        if (direction.isAscending()) {
+            return expression.asc();
+        }
+
+        return expression.desc();
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/presentation/CommentController.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/presentation/CommentController.java
@@ -1,0 +1,79 @@
+package com.dnd.spaced.core.comment.presentation;
+
+import com.dnd.spaced.core.comment.application.CommentService;
+import com.dnd.spaced.core.comment.application.dto.response.ReadAllCommentDto;
+import com.dnd.spaced.core.comment.presentation.dto.request.ReadAllCommentRequest;
+import com.dnd.spaced.core.comment.presentation.dto.request.SaveCommentRequest;
+import com.dnd.spaced.core.comment.presentation.dto.request.UpdateCommentRequest;
+import com.dnd.spaced.core.comment.presentation.dto.response.ReadAllCommentResponse;
+import com.dnd.spaced.global.auth.AuthAccount;
+import com.dnd.spaced.global.auth.AuthAccountInfo;
+import com.dnd.spaced.global.consts.controller.ResponseEntityConst;
+import com.dnd.spaced.global.resolver.comment.CommonCommentPageable;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/words/{wordId}/comments")
+    public ResponseEntity<Void> save(
+            @AuthAccount AuthAccountInfo accountInfo,
+            @Valid @RequestBody SaveCommentRequest request,
+            @PathVariable Long wordId
+    ) {
+        commentService.save(accountInfo.id(), wordId, request.content());
+
+        return ResponseEntity.created(URI.create("/words/" + wordId))
+                             .build();
+    }
+
+    @DeleteMapping("/comments/{id}")
+    public ResponseEntity<Void> delete(@AuthAccount AuthAccountInfo accountInfo, @PathVariable Long id) {
+        commentService.delete(accountInfo.id(), id);
+
+        return ResponseEntityConst.NO_CONTENT;
+    }
+
+    @PutMapping("/comments/{id}")
+    public ResponseEntity<Void> update(
+            @AuthAccount AuthAccountInfo accountInfo,
+            @Valid @RequestBody UpdateCommentRequest request,
+            @PathVariable Long id
+    ) {
+        commentService.update(accountInfo.id(), id, request.content());
+
+        return ResponseEntityConst.NO_CONTENT;
+    }
+
+    @GetMapping("/words/{wordId}/comments")
+    public ResponseEntity<ReadAllCommentResponse> readAlLBy(
+            @AuthAccount(required = false) AuthAccountInfo accountInfo,
+            @PathVariable Long wordId,
+            ReadAllCommentRequest request,
+            @CommonCommentPageable Pageable pageable
+    ) {
+        List<ReadAllCommentDto> result = commentService.readAllBy(
+                accountInfo.id(),
+                wordId,
+                request.lastCommentId(),
+                pageable
+        );
+
+        return ResponseEntity.ok(ReadAllCommentResponse.from(result));
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/presentation/dto/request/ReadAllCommentRequest.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/presentation/dto/request/ReadAllCommentRequest.java
@@ -1,0 +1,4 @@
+package com.dnd.spaced.core.comment.presentation.dto.request;
+
+public record ReadAllCommentRequest(Long lastCommentId) {
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/presentation/dto/request/SaveCommentRequest.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/presentation/dto/request/SaveCommentRequest.java
@@ -1,0 +1,6 @@
+package com.dnd.spaced.core.comment.presentation.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record SaveCommentRequest(@NotEmpty String content) {
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/presentation/dto/request/UpdateCommentRequest.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/presentation/dto/request/UpdateCommentRequest.java
@@ -1,0 +1,6 @@
+package com.dnd.spaced.core.comment.presentation.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record UpdateCommentRequest(@NotEmpty String content) {
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/comment/presentation/dto/response/ReadAllCommentResponse.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/comment/presentation/dto/response/ReadAllCommentResponse.java
@@ -1,0 +1,42 @@
+package com.dnd.spaced.core.comment.presentation.dto.response;
+
+import com.dnd.spaced.core.comment.application.dto.response.ReadAllCommentDto;
+import java.util.List;
+
+public record ReadAllCommentResponse(List<CommentInfoResponse> comments) {
+
+    private record CommentInfoResponse(DetailCommentInfoResponse commentInfo, WriterInfoResponse writerInfo) {
+
+        private record DetailCommentInfoResponse(Long id, Long wordId, String content, int likeCount) {
+        }
+
+        private record WriterInfoResponse(String id, String writerNickname, String writerProfileImage) {
+        }
+
+        static CommentInfoResponse from(ReadAllCommentDto dto) {
+            DetailCommentInfoResponse detailCommentInfoResponse = new DetailCommentInfoResponse(
+                    dto.commentInfo().id(),
+                    dto.commentInfo().wordId(),
+                    dto.commentInfo().content(),
+                    dto.commentInfo().likeCount()
+            );
+            WriterInfoResponse writerInfoResponse = new WriterInfoResponse(
+                    dto.writerInfo().id(),
+                    dto.writerInfo().writerNickname(),
+                    dto.writerInfo().writerProfileImage()
+            );
+            return new CommentInfoResponse(
+                    detailCommentInfoResponse,
+                    writerInfoResponse
+            );
+        }
+    }
+
+    public static ReadAllCommentResponse from(List<ReadAllCommentDto> dtos) {
+        List<CommentInfoResponse> comments = dtos.stream()
+                                                 .map(CommentInfoResponse::from)
+                                                 .toList();
+
+        return new ReadAllCommentResponse(comments);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/application/LikeService.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/application/LikeService.java
@@ -1,0 +1,45 @@
+package com.dnd.spaced.core.like.application;
+
+import com.dnd.spaced.core.account.domain.Account;
+import com.dnd.spaced.core.account.domain.repository.AccountRepository;
+import com.dnd.spaced.core.comment.domain.Comment;
+import com.dnd.spaced.core.comment.domain.repository.CommentRepository;
+import com.dnd.spaced.core.like.application.exception.ForbiddenLikeException;
+import com.dnd.spaced.core.like.application.exception.AssociationCommentNotFoundException;
+import com.dnd.spaced.core.like.domain.Like;
+import com.dnd.spaced.core.like.domain.repository.LikeCountRepository;
+import com.dnd.spaced.core.like.domain.repository.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+    private final CommentRepository commentRepository;
+    private final AccountRepository accountRepository;
+    private final LikeCountRepository likeCountRepository;
+
+    @Transactional
+    public void processLike(String accountId, Long commentId) {
+        Account account = accountRepository.findBy(accountId)
+                                           .orElseThrow(() -> new ForbiddenLikeException("좋아요를 제어할 권한이 없습니다."));
+        Comment comment = commentRepository.findBy(commentId)
+                                           .orElseThrow(() -> new AssociationCommentNotFoundException("좋아요 대상인 댓글을 찾을 수 없습니다."));
+
+        likeRepository.findBy(account.getId(), comment.getId())
+                      .ifPresentOrElse(
+                              like -> {
+                                  likeRepository.delete(like);
+                                  likeCountRepository.deleteLikeCount(comment.getWordId(), comment.getId());
+                              },
+                              () -> {
+                                  likeRepository.save(new Like(account.getId(), comment.getId()));
+                                  likeCountRepository.addLikeCount(comment.getWordId(), comment.getId());
+                              }
+                      );
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/application/exception/AssociationCommentNotFoundException.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/application/exception/AssociationCommentNotFoundException.java
@@ -1,0 +1,11 @@
+package com.dnd.spaced.core.like.application.exception;
+
+import com.dnd.spaced.global.exception.base.LikeClientException;
+import com.dnd.spaced.global.exception.code.LikeErrorCode;
+
+public class AssociationCommentNotFoundException extends LikeClientException {
+
+    public AssociationCommentNotFoundException(String message) {
+        super(LikeErrorCode.ASSOCIATION_COMMENT_NOT_FOUND, message);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/application/exception/ForbiddenLikeException.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/application/exception/ForbiddenLikeException.java
@@ -1,0 +1,11 @@
+package com.dnd.spaced.core.like.application.exception;
+
+import com.dnd.spaced.global.exception.base.LikeClientException;
+import com.dnd.spaced.global.exception.code.LikeErrorCode;
+
+public class ForbiddenLikeException extends LikeClientException {
+
+    public ForbiddenLikeException(String message) {
+        super(LikeErrorCode.FORBIDDEN_LIKE, message);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/application/schedule/LikeCountScheduler.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/application/schedule/LikeCountScheduler.java
@@ -1,0 +1,45 @@
+package com.dnd.spaced.core.like.application.schedule;
+
+import com.dnd.spaced.core.like.domain.repository.LikeCountRepository;
+import com.dnd.spaced.core.like.infrastructure.dto.response.LikeCountInfoDto;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class LikeCountScheduler {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final LikeCountRepository likeCountRepository;
+
+    @Scheduled(cron = "0 */30 * * * *")
+    @Transactional
+    public void schedule() {
+        List<LikeCountInfoDto> likeCountInfos = likeCountRepository.findLikeCountAll();
+
+        jdbcTemplate.batchUpdate(
+                "UPDATE comments c SET c.like_count =: likeCount WHERE c.id =: id",
+                new BatchPreparedStatementSetter() {
+
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        LikeCountInfoDto likeCountInfoDto = likeCountInfos.get(i);
+
+                        ps.setInt(1, likeCountInfoDto.likeCount());
+                        ps.setLong(2, likeCountInfoDto.commentId());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return 100;
+                    }
+                });
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/domain/Like.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/domain/Like.java
@@ -1,0 +1,32 @@
+package com.dnd.spaced.core.like.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "likes")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(callSuper = false, of ="id")
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String accountId;
+
+    private Long commentId;
+
+    public Like(String accountId, Long commentId) {
+        this.accountId = accountId;
+        this.commentId = commentId;
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/domain/repository/LikeCountRepository.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/domain/repository/LikeCountRepository.java
@@ -1,0 +1,16 @@
+package com.dnd.spaced.core.like.domain.repository;
+
+import com.dnd.spaced.core.like.infrastructure.dto.response.LikeCountInfoDto;
+import java.util.List;
+import java.util.Map;
+
+public interface LikeCountRepository {
+
+    List<LikeCountInfoDto> findLikeCountAll();
+
+    Map<Long, Integer> findLikeCountAllBy(Long wordId, List<Object> commentIds);
+
+    void addLikeCount(Long wordId, Long commentId);
+
+    void deleteLikeCount(Long wordId, Long commentId);
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/domain/repository/LikeRepository.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/domain/repository/LikeRepository.java
@@ -1,0 +1,13 @@
+package com.dnd.spaced.core.like.domain.repository;
+
+import com.dnd.spaced.core.like.domain.Like;
+import java.util.Optional;
+
+public interface LikeRepository {
+
+    void save(Like like);
+
+    void delete(Like like);
+
+    Optional<Like> findBy(String accountId, Long commentId);
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeCountBuffer.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeCountBuffer.java
@@ -1,0 +1,43 @@
+package com.dnd.spaced.core.like.infrastructure;
+
+import com.dnd.spaced.core.like.infrastructure.dto.LikeCountIdentifier;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class LikeCountBuffer {
+
+    private static final int FLUSH_THRESHOLD = 100;
+
+    private final AtomicInteger likeEventCount = new AtomicInteger(0);
+    private final AtomicReference<Map<LikeCountIdentifier, Integer>> currentBuffer = new AtomicReference<>(new ConcurrentHashMap<>());
+    private final Consumer<Map<LikeCountIdentifier, Integer>> cacheUpdateCallback;
+    private final Executor asyncCommentLikeCountExecutor;
+
+    public void addLikeCount(LikeCountIdentifier identifier) {
+        currentBuffer.get()
+                     .merge(identifier, 1, Integer::sum);
+
+        if (likeEventCount.incrementAndGet() >= FLUSH_THRESHOLD) {
+            flushBuffer();
+        }
+    }
+
+    public void deleteLikeCount(LikeCountIdentifier identifier) {
+        currentBuffer.get()
+                     .merge(identifier, -1, Integer::sum);
+    }
+
+    private void flushBuffer() {
+        Map<LikeCountIdentifier, Integer> buffer = currentBuffer.getAndSet(new ConcurrentHashMap<>());
+
+        CompletableFuture.runAsync(() -> cacheUpdateCallback.accept(buffer), asyncCommentLikeCountExecutor);
+        likeEventCount.set(0);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeCountRedisRepository.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeCountRedisRepository.java
@@ -1,0 +1,95 @@
+package com.dnd.spaced.core.like.infrastructure;
+
+import com.dnd.spaced.core.like.infrastructure.dto.LikeCountIdentifier;
+import com.dnd.spaced.core.like.domain.repository.LikeCountRepository;
+import com.dnd.spaced.core.like.infrastructure.dto.response.LikeCountInfoDto;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class LikeCountRedisRepository implements LikeCountRepository {
+
+    private static final String KEY = "likeCount:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final LikeCountBuffer buffer;
+
+    public LikeCountRedisRepository(
+            RedisTemplate<String, String> redisTemplate,
+            Executor asyncCommentLikeCountExecutor
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.buffer = new LikeCountBuffer(this::updateCache, asyncCommentLikeCountExecutor);
+    }
+
+    @Override
+    public List<LikeCountInfoDto> findLikeCountAll() {
+        List<LikeCountInfoDto> result = new ArrayList<>();
+        ScanOptions options = ScanOptions.scanOptions()
+                                         .match(KEY + "*")
+                                         .count(10)
+                                         .build();
+        Cursor<String> cursor = redisTemplate.scan(options);
+
+        while (cursor.hasNext()) {
+            String key = cursor.next();
+            redisTemplate.opsForHash()
+                         .entries(key)
+                         .forEach(
+                                 (member, value) -> result.add(
+                                         new LikeCountInfoDto(
+                                                 Long.parseLong((String) member),
+                                                 Integer.parseInt((String) value)
+                                         )
+                                 )
+                         );
+        }
+
+        return result;
+    }
+
+    @Override
+    public Map<Long, Integer> findLikeCountAllBy(Long wordId, List<Object> commentIds) {
+        List<Object> objects = redisTemplate.opsForHash()
+                                            .multiGet(calculateKey(wordId), commentIds);
+        Map<Long, Integer> result = new HashMap<>();
+
+        for (int i = 0; i < objects.size(); i++) {
+            result.put((Long) commentIds.get(i), (Integer) objects.get(i));
+        }
+
+        return result;
+    }
+
+    @Override
+    public void addLikeCount(Long wordId, Long commentId) {
+        buffer.addLikeCount(new LikeCountIdentifier(wordId, commentId));
+    }
+
+    @Override
+    public void deleteLikeCount(Long wordId, Long commentId) {
+        buffer.deleteLikeCount(new LikeCountIdentifier(wordId, commentId));
+    }
+
+    private String calculateKey(Long wordId) {
+        return KEY + wordId;
+    }
+
+    private void updateCache(Map<LikeCountIdentifier, Integer> buffer) {
+        buffer.forEach(
+                (identifier, count) -> redisTemplate.opsForHash()
+                                                    .increment(
+                                                            calculateKey(identifier.wordId()),
+                                                            identifier.commentId(),
+                                                            count
+                                                    )
+        );
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeCrudRepository.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeCrudRepository.java
@@ -1,0 +1,7 @@
+package com.dnd.spaced.core.like.infrastructure;
+
+import com.dnd.spaced.core.like.domain.Like;
+import org.springframework.data.repository.CrudRepository;
+
+interface LikeCrudRepository extends CrudRepository<Like, Long> {
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeQueryRepository.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeQueryRepository.java
@@ -1,0 +1,37 @@
+package com.dnd.spaced.core.like.infrastructure;
+
+import static com.dnd.spaced.core.like.domain.QLike.like;
+
+import com.dnd.spaced.core.like.domain.Like;
+import com.dnd.spaced.core.like.domain.repository.LikeRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LikeQueryRepository implements LikeRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final LikeCrudRepository likeCrudRepository;
+
+    @Override
+    public void save(Like like) {
+        likeCrudRepository.save(like);
+    }
+
+    @Override
+    public void delete(Like like) {
+        likeCrudRepository.delete(like);
+    }
+
+    @Override
+    public Optional<Like> findBy(String accountId, Long commentId) {
+        Like result = queryFactory.selectFrom(like)
+                                  .where(like.accountId.eq(accountId), like.commentId.eq(commentId))
+                                  .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/dto/LikeCountIdentifier.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/dto/LikeCountIdentifier.java
@@ -1,0 +1,4 @@
+package com.dnd.spaced.core.like.infrastructure.dto;
+
+public record LikeCountIdentifier(Long wordId, Long commentId) {
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/dto/response/LikeCountInfoDto.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/dto/response/LikeCountInfoDto.java
@@ -1,0 +1,4 @@
+package com.dnd.spaced.core.like.infrastructure.dto.response;
+
+public record LikeCountInfoDto(Long commentId, int likeCount) {
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/presentation/LikeController.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/presentation/LikeController.java
@@ -1,0 +1,25 @@
+package com.dnd.spaced.core.like.presentation;
+
+import com.dnd.spaced.core.like.application.LikeService;
+import com.dnd.spaced.global.auth.AuthAccount;
+import com.dnd.spaced.global.auth.AuthAccountInfo;
+import com.dnd.spaced.global.consts.controller.ResponseEntityConst;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class LikeController {
+
+    private final LikeService likeService;
+
+    @PostMapping("/comments/{commentId}/likes")
+    public ResponseEntity<Void> processLike(@AuthAccount AuthAccountInfo accountInfo, @PathVariable Long commentId) {
+        likeService.processLike(accountInfo.id(), commentId);
+
+        return ResponseEntityConst.NO_CONTENT;
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/global/config/AppConfig.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/config/AppConfig.java
@@ -2,6 +2,7 @@ package com.dnd.spaced.global.config;
 
 import com.dnd.spaced.global.auth.interceptor.AuthInterceptor;
 import com.dnd.spaced.global.auth.resolver.AuthAccountInfoArgumentResolver;
+import com.dnd.spaced.global.resolver.comment.CommonCommentPageableArgumentResolver;
 import com.dnd.spaced.global.resolver.word.CommonWordPageableArgumentResolver;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
@@ -30,6 +31,7 @@ public class AppConfig implements WebMvcConfigurer {
     private final AuthInterceptor authInterceptor;
     private final AuthAccountInfoArgumentResolver authAccountInfoArgumentResolver;
     private final CommonWordPageableArgumentResolver commonWordPageableArgumentResolver;
+    private final CommonCommentPageableArgumentResolver commonCommentPageableArgumentResolver;
 
     @Bean
     public Clock clock() {
@@ -53,14 +55,39 @@ public class AppConfig implements WebMvcConfigurer {
     public Executor asyncWordViewCountExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 
-        executor.setCorePoolSize(4);
-        executor.setMaxPoolSize(10);
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        int corePoolSize = Math.max(1, availableProcessors / 6);
+        int maxPoolSize = Math.max(2, corePoolSize * 2);
+
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
         executor.setQueueCapacity(10);
         executor.setKeepAliveSeconds(180);
         executor.setAllowCoreThreadTimeOut(true);
         executor.setAwaitTerminationSeconds(20);
         executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
-        executor.setThreadNamePrefix("Async-Word-View-Count-");
+        executor.setThreadNamePrefix("Async-Word-ViewCount-");
+        executor.initialize();
+
+        return executor;
+    }
+
+    @Bean
+    public Executor asyncCommentLikeCountExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        int availableProcessors = Runtime.getRuntime().availableProcessors();
+        int corePoolSize = Math.max(1, availableProcessors / 6);
+        int maxPoolSize = Math.max(2, corePoolSize * 2);
+
+        executor.setCorePoolSize(corePoolSize);
+        executor.setMaxPoolSize(maxPoolSize);
+        executor.setQueueCapacity(10);
+        executor.setKeepAliveSeconds(180);
+        executor.setAllowCoreThreadTimeOut(true);
+        executor.setAwaitTerminationSeconds(20);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+        executor.setThreadNamePrefix("Async-Comment-LikeCount-");
         executor.initialize();
 
         return executor;
@@ -70,6 +97,7 @@ public class AppConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authAccountInfoArgumentResolver);
         resolvers.add(commonWordPageableArgumentResolver);
+        resolvers.add(commonCommentPageableArgumentResolver);
     }
 
     @Override

--- a/space-d/src/main/java/com/dnd/spaced/global/config/RedisConfig.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -35,5 +36,17 @@ public class RedisConfig {
         popularWordIdRedisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         
         return popularWordIdRedisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, Long> likeCountRedisTemplate() {
+        RedisTemplate<String, Long> likeCountRedisTemplate = new RedisTemplate<>();
+
+        likeCountRedisTemplate.setConnectionFactory(redisConnectionFactory);
+        likeCountRedisTemplate.setKeySerializer(new StringRedisSerializer());
+        likeCountRedisTemplate.setHashKeySerializer(new GenericToStringSerializer<>(Long.class));
+        likeCountRedisTemplate.setHashValueSerializer(new GenericToStringSerializer<>(Integer.class));
+
+        return likeCountRedisTemplate;
     }
 }

--- a/space-d/src/main/java/com/dnd/spaced/global/config/SecurityConfig.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/config/SecurityConfig.java
@@ -86,6 +86,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(authorize -> authorize
                     .requestMatchers(HttpMethod.POST, "/auths/refresh-token").permitAll()
                     .requestMatchers(HttpMethod.GET, "/words/**").permitAll()
+                    .requestMatchers(HttpMethod.GET, "/words/{wordId}/comments").permitAll()
                     .requestMatchers("/admin/**").hasRole("ADMIN")
                     .anyRequest().authenticated()
             )

--- a/space-d/src/main/java/com/dnd/spaced/global/consts/resolver/ResolverConst.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/consts/resolver/ResolverConst.java
@@ -1,0 +1,11 @@
+package com.dnd.spaced.global.consts.resolver;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ResolverConst {
+
+    public static final String SORT_ORDER_PARAMETER_NAME = "sortOrder";
+    public static final String SORT_CONDITION_PARAMETER_NAME = "sortCondition";
+}

--- a/space-d/src/main/java/com/dnd/spaced/global/exception/GlobalControllerAdvice.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/exception/GlobalControllerAdvice.java
@@ -5,6 +5,7 @@ import com.dnd.spaced.global.exception.base.AccountServerException;
 import com.dnd.spaced.global.exception.base.AuthClientException;
 import com.dnd.spaced.global.exception.base.AuthServerException;
 import com.dnd.spaced.global.exception.base.CommentClientException;
+import com.dnd.spaced.global.exception.base.LikeClientException;
 import com.dnd.spaced.global.exception.response.ExceptionDto;
 import com.dnd.spaced.global.exception.translator.AccountExceptionTranslator;
 import com.dnd.spaced.global.exception.translator.AuthExceptionTranslator;
@@ -75,6 +76,16 @@ public class GlobalControllerAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(CommentClientException.class)
     private ResponseEntity<ExceptionDto> handleCommentClientException(CommentClientException ex) {
+        logger.warn(String.format(LOG_FORMAT, ex.getClass().getSimpleName()), ex);
+
+        ExceptionTranslator translator = AuthExceptionTranslator.findBy(ex.getErrorCode());
+
+        return ResponseEntity.status(translator.getHttpStatus())
+                             .body(translator.translate());
+    }
+
+    @ExceptionHandler(LikeClientException.class)
+    private ResponseEntity<ExceptionDto> handleLikeClientException(LikeClientException ex) {
         logger.warn(String.format(LOG_FORMAT, ex.getClass().getSimpleName()), ex);
 
         ExceptionTranslator translator = AuthExceptionTranslator.findBy(ex.getErrorCode());

--- a/space-d/src/main/java/com/dnd/spaced/global/exception/GlobalControllerAdvice.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/exception/GlobalControllerAdvice.java
@@ -4,6 +4,7 @@ import com.dnd.spaced.global.exception.base.AccountClientException;
 import com.dnd.spaced.global.exception.base.AccountServerException;
 import com.dnd.spaced.global.exception.base.AuthClientException;
 import com.dnd.spaced.global.exception.base.AuthServerException;
+import com.dnd.spaced.global.exception.base.CommentClientException;
 import com.dnd.spaced.global.exception.response.ExceptionDto;
 import com.dnd.spaced.global.exception.translator.AccountExceptionTranslator;
 import com.dnd.spaced.global.exception.translator.AuthExceptionTranslator;
@@ -64,6 +65,16 @@ public class GlobalControllerAdvice extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(AuthClientException.class)
     private ResponseEntity<ExceptionDto> handleAuthClientException(AuthClientException ex) {
+        logger.warn(String.format(LOG_FORMAT, ex.getClass().getSimpleName()), ex);
+
+        ExceptionTranslator translator = AuthExceptionTranslator.findBy(ex.getErrorCode());
+
+        return ResponseEntity.status(translator.getHttpStatus())
+                             .body(translator.translate());
+    }
+
+    @ExceptionHandler(CommentClientException.class)
+    private ResponseEntity<ExceptionDto> handleCommentClientException(CommentClientException ex) {
         logger.warn(String.format(LOG_FORMAT, ex.getClass().getSimpleName()), ex);
 
         ExceptionTranslator translator = AuthExceptionTranslator.findBy(ex.getErrorCode());

--- a/space-d/src/main/java/com/dnd/spaced/global/exception/base/CommentClientException.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/exception/base/CommentClientException.java
@@ -1,0 +1,14 @@
+package com.dnd.spaced.global.exception.base;
+
+import com.dnd.spaced.global.exception.code.ErrorCode;
+
+public class CommentClientException extends BaseClientException {
+
+    public CommentClientException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public CommentClientException(ErrorCode errorCode, String message, Throwable e) {
+        super(errorCode, message, e);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/global/exception/base/LikeClientException.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/exception/base/LikeClientException.java
@@ -1,0 +1,14 @@
+package com.dnd.spaced.global.exception.base;
+
+import com.dnd.spaced.global.exception.code.ErrorCode;
+
+public class LikeClientException extends BaseClientException {
+
+    public LikeClientException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+    public LikeClientException(ErrorCode errorCode, String message, Throwable e) {
+        super(errorCode, message, e);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/global/exception/code/CommentErrorCode.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/exception/code/CommentErrorCode.java
@@ -2,5 +2,9 @@ package com.dnd.spaced.global.exception.code;
 
 public enum CommentErrorCode implements ErrorCode {
 
-    INVALID_COMMENT_CONTENT
+    INVALID_COMMENT_CONTENT,
+    ASSOCIATION_WORD_NOT_FOUND,
+    ASSOCIATION_ACCOUNT_NOT_FOUND,
+    COMMENT_NOT_FOUND,
+    FORBIDDEN_COMMENT
 }

--- a/space-d/src/main/java/com/dnd/spaced/global/exception/code/CommentErrorCode.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/exception/code/CommentErrorCode.java
@@ -1,0 +1,6 @@
+package com.dnd.spaced.global.exception.code;
+
+public enum CommentErrorCode implements ErrorCode {
+
+    INVALID_COMMENT_CONTENT
+}

--- a/space-d/src/main/java/com/dnd/spaced/global/exception/code/LikeErrorCode.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/exception/code/LikeErrorCode.java
@@ -1,0 +1,7 @@
+package com.dnd.spaced.global.exception.code;
+
+public enum LikeErrorCode implements ErrorCode {
+
+    FORBIDDEN_LIKE,
+    ASSOCIATION_COMMENT_NOT_FOUND
+}

--- a/space-d/src/main/java/com/dnd/spaced/global/exception/translator/CommentExceptionTranslator.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/exception/translator/CommentExceptionTranslator.java
@@ -1,0 +1,63 @@
+package com.dnd.spaced.global.exception.translator;
+
+import com.dnd.spaced.global.exception.code.CommentErrorCode;
+import com.dnd.spaced.global.exception.code.ErrorCode;
+import com.dnd.spaced.global.exception.response.ExceptionDto;
+import java.util.Arrays;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum CommentExceptionTranslator implements ExceptionTranslator {
+    ASSOCIATION_ACCOUNT_NOT_FOUND_EXCEPTION(
+            CommentErrorCode.ASSOCIATION_ACCOUNT_NOT_FOUND,
+            HttpStatus.FORBIDDEN,
+            "유효하지 않은 회원입니다."
+    ),
+    ASSOCIATION_WORD_NOT_FOUND_EXCEPTION(
+            CommentErrorCode.ASSOCIATION_WORD_NOT_FOUND,
+            HttpStatus.BAD_REQUEST,
+            "댓글과 관련된 용어를 찾을 수 없습니다."
+    ),
+    COMMENT_NOT_FOUND_EXCEPTION(
+            CommentErrorCode.COMMENT_NOT_FOUND,
+            HttpStatus.BAD_REQUEST,
+            "지정한 ID에 해당하는 댓글이 없습니다."
+    ),
+    FORBIDDEN_COMMENT_EXCEPTION(
+            CommentErrorCode.FORBIDDEN_COMMENT,
+            HttpStatus.FORBIDDEN,
+            "요청을 수행할 수 있는 권한이 없습니다."
+    ),
+    INVALID_COMMENT_CONTENT_EXCEPTION(
+            CommentErrorCode.INVALID_COMMENT_CONTENT,
+            HttpStatus.BAD_REQUEST,
+            "댓글 내용은 최소 1글자 이상, 최소 100글자 이하여야 합니다."
+    );
+
+    private final ErrorCode errorCode;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    CommentExceptionTranslator(ErrorCode errorCode, HttpStatus httpStatus, String message) {
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public static CommentExceptionTranslator findBy(ErrorCode errorCode) {
+        return Arrays.stream(CommentExceptionTranslator.values())
+                     .filter(translator -> translator.errorCode == errorCode)
+                     .findAny()
+                     .orElseThrow(
+                             () -> new IllegalStateException(
+                                     errorCode.toString() + "으로 정의된 예외 번역기가 존재하지 않습니다."
+                             )
+                     );
+    }
+
+    @Override
+    public ExceptionDto translate() {
+        return new ExceptionDto(this.errorCode.toString(), this.message);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/global/exception/translator/LikeExceptionTranslator.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/exception/translator/LikeExceptionTranslator.java
@@ -1,0 +1,48 @@
+package com.dnd.spaced.global.exception.translator;
+
+import com.dnd.spaced.global.exception.code.ErrorCode;
+import com.dnd.spaced.global.exception.code.LikeErrorCode;
+import com.dnd.spaced.global.exception.response.ExceptionDto;
+import java.util.Arrays;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum LikeExceptionTranslator implements ExceptionTranslator{
+    FORBIDDEN_LIKE_EXCEPTION(
+            LikeErrorCode.FORBIDDEN_LIKE,
+            HttpStatus.FORBIDDEN,
+            "좋아요를 제어할 권한이 없습니다."
+    ),
+    ASSOCIATION_COMMENT_NOT_FOUND_EXCEPTION(
+            LikeErrorCode.ASSOCIATION_COMMENT_NOT_FOUND,
+            HttpStatus.NOT_FOUND,
+            "좋아요 대상인 댓글을 찾을 수 없습니다."
+    );
+
+    private final ErrorCode errorCode;
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    LikeExceptionTranslator(ErrorCode errorCode, HttpStatus httpStatus, String message) {
+        this.errorCode = errorCode;
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public static LikeExceptionTranslator findBy(ErrorCode errorCode) {
+        return Arrays.stream(LikeExceptionTranslator.values())
+                     .filter(translator -> translator.errorCode == errorCode)
+                     .findAny()
+                     .orElseThrow(
+                             () -> new IllegalStateException(
+                                     errorCode.toString() + "으로 정의된 예외 번역기가 존재하지 않습니다."
+                             )
+                     );
+    }
+
+    @Override
+    public ExceptionDto translate() {
+        return new ExceptionDto(this.errorCode.toString(), this.message);
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/global/resolver/comment/CommonCommentPageable.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/resolver/comment/CommonCommentPageable.java
@@ -1,0 +1,11 @@
+package com.dnd.spaced.global.resolver.comment;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CommonCommentPageable {
+}

--- a/space-d/src/main/java/com/dnd/spaced/global/resolver/comment/CommonCommentPageableArgumentResolver.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/resolver/comment/CommonCommentPageableArgumentResolver.java
@@ -1,0 +1,56 @@
+package com.dnd.spaced.global.resolver.comment;
+
+import com.dnd.spaced.global.consts.resolver.ResolverConst;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class CommonCommentPageableArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final int IGNORED_PAGE = 0;
+    private static final int DEFAULT_SIZE = 10;
+    private static final String DEFAULT_SORT_CONDITION = "likeCount";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CommonCommentPageable.class) && parameter.getParameterType()
+                                                                                         .equals(Pageable.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        Direction direction = findDirection(webRequest.getParameter(ResolverConst.SORT_ORDER_PARAMETER_NAME));
+        String sortCondition = findSortCondition(webRequest.getParameter(ResolverConst.SORT_CONDITION_PARAMETER_NAME));
+
+        return PageRequest.of(IGNORED_PAGE, DEFAULT_SIZE)
+                          .withSort(direction, sortCondition);
+    }
+
+    private Direction findDirection(String target) {
+        if (target == null || Direction.DESC.name().equalsIgnoreCase(target)) {
+            return Direction.DESC;
+        }
+
+        return Direction.ASC;
+    }
+
+    private String findSortCondition(String target) {
+        if (target == null) {
+            return DEFAULT_SORT_CONDITION;
+        }
+
+        return target;
+    }
+}

--- a/space-d/src/main/resources/static/docs/index.html
+++ b/space-d/src/main/resources/static/docs/index.html
@@ -839,7 +839,7 @@ Cookie: refreshToken=Bearer refreshToken</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: refreshToken=refreshToken; Path=/; Max-Age=259200; Expires=Sun, 22 Sep 2024 14:53:57 GMT; Secure; HttpOnly; SameSite=NONE
+Set-Cookie: refreshToken=refreshToken; Path=/; Max-Age=259200; Expires=Sun, 22 Sep 2024 15:21:34 GMT; Secure; HttpOnly; SameSite=NONE
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -3057,11 +3057,115 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="Like-API"><a class="link" href="#Like-API">Like API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="Process-Like"><a class="link" href="#Process-Like">좋아요 API</a></h3>
+<div class="sect3">
+<h4 id="Process-Like_http_request"><a class="link" href="#Process-Like_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /comments/1/likes HTTP/1.1
+Authorization: Bearer AccessToken
+Content-Type: application/x-www-form-urlencoded</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Process-Like_request_headers"><a class="link" href="#Process-Like_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bearer 타입의 Access Token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Process-Like_path_parameters"><a class="link" href="#Process-Like_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>commentId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 추가/취소를 수소할 댓글 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Process-Like_http_response"><a class="link" href="#Process-Like_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+<div class="paragraph">
+<p><code>POST /comments/{commentId}/likes</code> 예외 상황</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">에러 코드</th>
+<th class="tableblock halign-left valign-top">HTTP Status 이름</th>
+<th class="tableblock halign-left valign-top">HTTP Status 값</th>
+<th class="tableblock halign-left valign-top">메시지</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FORBIDDEN_LIKE</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FORBIDDEN</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">403</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요를 제어할 권한이 없습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ASSOCIATION_COMMENT_NOT_FOUND</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">NOT_FOUND</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">404</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 대상인 댓글을 찾을 수 없습니다.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-09-19 23:53:35 +0900
+Last updated 2024-09-20 00:21:18 +0900
 </div>
 </div>
 </body>

--- a/space-d/src/main/resources/static/docs/index.html
+++ b/space-d/src/main/resources/static/docs/index.html
@@ -839,7 +839,7 @@ Cookie: refreshToken=Bearer refreshToken</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: refreshToken=refreshToken; Path=/; Max-Age=259200; Expires=Fri, 13 Sep 2024 12:44:01 GMT; Secure; HttpOnly; SameSite=NONE
+Set-Cookie: refreshToken=refreshToken; Path=/; Max-Age=259200; Expires=Sun, 22 Sep 2024 14:53:57 GMT; Secure; HttpOnly; SameSite=NONE
 Content-Type: application/json;charset=UTF-8
 
 {
@@ -2073,17 +2073,21 @@ Accept: application/json</code></pre>
 <h4 id="Read-Word_path_parameters"><a class="link" href="#Read-Word_path_parameters">Path parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
 <th class="tableblock halign-left valign-top">이름</th>
-<th class="tableblock halign-left valign-top">필수여부</th>
 <th class="tableblock halign-left valign-top">설명</th>
 </tr>
 </thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회하고자 하는 용어 ID</p></td>
+</tr>
+</tbody>
 </table>
 </div>
 <div class="sect3">
@@ -2508,11 +2512,556 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="Comment-API"><a class="link" href="#Comment-API">Comment API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="Save-Comment"><a class="link" href="#Save-Comment">댓글 추가 API</a></h3>
+<div class="sect3">
+<h4 id="Save-Comment_http_request"><a class="link" href="#Save-Comment_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /words/1/comments HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer AccessToken
+
+{
+  "content" : "content"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Save-Comment_request_headers"><a class="link" href="#Save-Comment_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bearer 타입의 Access Token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Save-Comment_path_parameters"><a class="link" href="#Save-Comment_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>wordId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글을 추가할 용어 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Save-Comment_request_fields"><a class="link" href="#Save-Comment_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Save-Comment_http_response"><a class="link" href="#Save-Comment_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 201 Created
+Location: /words/1</code></pre>
+</div>
+</div>
+</div>
+<div class="paragraph">
+<p><code>POST /words/{wordId}/comments</code> 예외 상황</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">에러 코드</th>
+<th class="tableblock halign-left valign-top">HTTP Status 이름</th>
+<th class="tableblock halign-left valign-top">HTTP Status 값</th>
+<th class="tableblock halign-left valign-top">메시지</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ASSOCIATION_ACCOUNT_NOT_FOUND</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FORBIDDEN</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">403</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유효하지 않은 회원입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ASSOCIATION_WORD_NOT_FOUND</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BAD_REQUEST</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글과 관련된 용어를 찾을 수 없습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>INVALID_COMMENT_CONTENT</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BAD_REQUEST</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용은 최소 1글자 이상, 최소 100글자 이하여야 합니다.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="Delete-Comment"><a class="link" href="#Delete-Comment">댓글 삭제 API</a></h3>
+<div class="sect3">
+<h4 id="Delete-Comment_http_request"><a class="link" href="#Delete-Comment_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">DELETE /comments/1 HTTP/1.1
+Authorization: Bearer AccessToken</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Delete-Comment_request_headers"><a class="link" href="#Delete-Comment_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bearer 타입의 Access Token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Delete-Comment_path_parameters"><a class="link" href="#Delete-Comment_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">삭제할 댓글 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Delete-Comment_http_response"><a class="link" href="#Delete-Comment_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+<div class="paragraph">
+<p><code>DELETE /comments/{id}</code> 예외 상황</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">에러 코드</th>
+<th class="tableblock halign-left valign-top">HTTP Status 이름</th>
+<th class="tableblock halign-left valign-top">HTTP Status 값</th>
+<th class="tableblock halign-left valign-top">메시지</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ASSOCIATION_ACCOUNT_NOT_FOUND</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FORBIDDEN</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">403</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유효하지 않은 회원입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ASSOCIATION_WORD_NOT_FOUND</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BAD_REQUEST</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글과 관련된 용어를 찾을 수 없습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FORBIDDEN_COMMENT</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FORBIDDEN</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">403</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청을 수행할 수 있는 권한이 없습니다.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="Update-Comment"><a class="link" href="#Update-Comment">댓글 수정 API</a></h3>
+<div class="sect3">
+<h4 id="Update-Comment_http_request"><a class="link" href="#Update-Comment_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">PUT /comments/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer AccessToken
+
+{
+  "content" : "change content"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Update-Comment_request_headers"><a class="link" href="#Update-Comment_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bearer 타입의 Access Token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Update-Comment_path_parameters"><a class="link" href="#Update-Comment_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수정할 댓글 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Update-Comment_request_fields"><a class="link" href="#Update-Comment_request_fields">Request fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수정할 댓글 내용</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Update-Comment_http_response"><a class="link" href="#Update-Comment_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 204 No Content</code></pre>
+</div>
+</div>
+</div>
+<div class="paragraph">
+<p><code>PUT /comments/{id}</code> 예외 상황</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">에러 코드</th>
+<th class="tableblock halign-left valign-top">HTTP Status 이름</th>
+<th class="tableblock halign-left valign-top">HTTP Status 값</th>
+<th class="tableblock halign-left valign-top">메시지</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ASSOCIATION_ACCOUNT_NOT_FOUND</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FORBIDDEN</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">403</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유효하지 않은 회원입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ASSOCIATION_WORD_NOT_FOUND</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BAD_REQUEST</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글과 관련된 용어를 찾을 수 없습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>FORBIDDEN_COMMENT</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FORBIDDEN</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">403</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청을 수행할 수 있는 권한이 없습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>INVALID_COMMENT_CONTENT</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">BAD_REQUEST</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용은 최소 1글자 이상, 최소 100글자 이하여야 합니다.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="Read-All-Comments"><a class="link" href="#Read-All-Comments">댓글 목록 조회 API</a></h3>
+<div class="sect3">
+<h4 id="Read-All-Comments_http_request"><a class="link" href="#Read-All-Comments_http_request">HTTP request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">GET /words/1/comments HTTP/1.1
+Accept: application/json</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Read-All-Comments_request_headers"><a class="link" href="#Read-All-Comments_request_headers">Request headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bearer 타입의 Access Token</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Read-All-Comments_path_parameters"><a class="link" href="#Read-All-Comments_path_parameters">Path parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">이름</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>wordId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 목록을 조회할 용어 ID</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="Read-All-Comments_http_response"><a class="link" href="#Read-All-Comments_http_response">HTTP response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "comments" : [ {
+    "commentInfo" : {
+      "id" : 1,
+      "wordId" : 1,
+      "content" : "content",
+      "likeCount" : 0
+    },
+    "writerInfo" : {
+      "id" : "accountId",
+      "writerNickname" : "writer",
+      "writerProfileImage" : "profileImage"
+    }
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="Read-All-Comments_response_fields"><a class="link" href="#Read-All-Comments_response_fields">Response fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 목록 조회 결과</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[*].commentInfo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[*].commentInfo.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[*].commentInfo.wordId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글이 추가된 용어 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[*].commentInfo.content</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[*].commentInfo.likeCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">댓글 좋아요 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[*].writerInfo</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[*].writerInfo.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 ID</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[*].writerInfo.writerNickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>comments[*].writerInfo.writerProfileImage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">작성자 프로필 이미지</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2024-09-10 20:39:35 +0900
+Last updated 2024-09-19 23:53:35 +0900
 </div>
 </div>
 </body>

--- a/space-d/src/test/java/com/dnd/spaced/config/common/CommonControllerSliceTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/config/common/CommonControllerSliceTest.java
@@ -13,12 +13,15 @@ import com.dnd.spaced.core.auth.application.BlacklistTokenService;
 import com.dnd.spaced.core.auth.application.InitAccountInfoService;
 import com.dnd.spaced.core.auth.domain.TokenDecoder;
 import com.dnd.spaced.core.auth.presentation.AuthController;
+import com.dnd.spaced.core.comment.application.CommentService;
+import com.dnd.spaced.core.comment.presentation.CommentController;
 import com.dnd.spaced.core.word.application.WordService;
 import com.dnd.spaced.core.word.presentation.WordController;
 import com.dnd.spaced.global.auth.AuthStore;
 import com.dnd.spaced.global.auth.interceptor.AuthInterceptor;
 import com.dnd.spaced.global.auth.resolver.AuthAccountInfoArgumentResolver;
 import com.dnd.spaced.global.exception.GlobalControllerAdvice;
+import com.dnd.spaced.global.resolver.comment.CommonCommentPageableArgumentResolver;
 import com.dnd.spaced.global.resolver.word.CommonWordPageableArgumentResolver;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +45,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @WebMvcTest(
         controllers = {
                 AuthController.class, DocsController.class, AdminController.class, AccountController.class,
-                WordController.class
+                WordController.class, CommentController.class
         },
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
@@ -54,6 +57,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @AutoConfigureRestDocs
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class CommonControllerSliceTest {
+
+    @Autowired
+    protected DocsController commonDocsController;
 
     @Autowired
     protected ObjectMapper objectMapper;
@@ -79,6 +85,9 @@ public class CommonControllerSliceTest {
     @Autowired
     protected WordController wordController;
 
+    @Autowired
+    protected CommentController commentController;
+
     @MockBean
     protected AccountService accountService;
 
@@ -97,8 +106,8 @@ public class CommonControllerSliceTest {
     @MockBean
     protected WordService wordService;
 
-    @Autowired
-    protected DocsController commonDocsController;
+    @MockBean
+    protected CommentService commentService;
 
     protected MockMvc mockMvc;
 
@@ -108,19 +117,22 @@ public class CommonControllerSliceTest {
         AuthInterceptor authInterceptor = new AuthInterceptor(store);
         AuthAccountInfoArgumentResolver authAccountInfoArgumentResolver = new AuthAccountInfoArgumentResolver(store);
         CommonWordPageableArgumentResolver commonWordPageableArgumentResolver = new CommonWordPageableArgumentResolver();
+        CommonCommentPageableArgumentResolver commonCommentPageableArgumentResolver = new CommonCommentPageableArgumentResolver();
 
         this.mockMvc = MockMvcBuilders.standaloneSetup(
                                               authController,
                                               adminController,
                                               accountController,
                                               commonDocsController,
-                                              wordController
+                                              wordController,
+                                              commentController
                                       )
                                       .setControllerAdvice(new GlobalControllerAdvice())
                                       .addInterceptors(authInterceptor)
                                       .setCustomArgumentResolvers(
                                               authAccountInfoArgumentResolver,
-                                              commonWordPageableArgumentResolver
+                                              commonWordPageableArgumentResolver,
+                                              commonCommentPageableArgumentResolver
                                       )
                                       .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
                                       .addFilters(new CharacterEncodingFilter("UTF-8", true))

--- a/space-d/src/test/java/com/dnd/spaced/config/common/CommonControllerSliceTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/config/common/CommonControllerSliceTest.java
@@ -15,6 +15,8 @@ import com.dnd.spaced.core.auth.domain.TokenDecoder;
 import com.dnd.spaced.core.auth.presentation.AuthController;
 import com.dnd.spaced.core.comment.application.CommentService;
 import com.dnd.spaced.core.comment.presentation.CommentController;
+import com.dnd.spaced.core.like.application.LikeService;
+import com.dnd.spaced.core.like.presentation.LikeController;
 import com.dnd.spaced.core.word.application.WordService;
 import com.dnd.spaced.core.word.presentation.WordController;
 import com.dnd.spaced.global.auth.AuthStore;
@@ -45,7 +47,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @WebMvcTest(
         controllers = {
                 AuthController.class, DocsController.class, AdminController.class, AccountController.class,
-                WordController.class, CommentController.class
+                WordController.class, CommentController.class, LikeController.class
         },
         excludeFilters = {
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = WebMvcConfigurer.class),
@@ -88,6 +90,9 @@ public class CommonControllerSliceTest {
     @Autowired
     protected CommentController commentController;
 
+    @Autowired
+    protected LikeController likeController;
+
     @MockBean
     protected AccountService accountService;
 
@@ -109,6 +114,9 @@ public class CommonControllerSliceTest {
     @MockBean
     protected CommentService commentService;
 
+    @MockBean
+    protected LikeService likeService;
+
     protected MockMvc mockMvc;
 
     @BeforeEach
@@ -125,7 +133,8 @@ public class CommonControllerSliceTest {
                                               accountController,
                                               commonDocsController,
                                               wordController,
-                                              commentController
+                                              commentController,
+                                              likeController
                                       )
                                       .setControllerAdvice(new GlobalControllerAdvice())
                                       .addInterceptors(authInterceptor)

--- a/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/DocsController.java
+++ b/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/DocsController.java
@@ -12,10 +12,12 @@ import com.dnd.spaced.core.word.domain.Category;
 import com.dnd.spaced.core.word.domain.PronunciationType;
 import com.dnd.spaced.global.exception.code.AccountErrorCode;
 import com.dnd.spaced.global.exception.code.AuthErrorCode;
+import com.dnd.spaced.global.exception.code.CommentErrorCode;
 import com.dnd.spaced.global.exception.code.WordErrorCode;
 import com.dnd.spaced.global.exception.response.ExceptionDto;
 import com.dnd.spaced.global.exception.translator.AccountExceptionTranslator;
 import com.dnd.spaced.global.exception.translator.AuthExceptionTranslator;
+import com.dnd.spaced.global.exception.translator.CommentExceptionTranslator;
 import com.dnd.spaced.global.exception.translator.ExceptionTranslator;
 import com.dnd.spaced.global.exception.translator.WordExceptionTranslator;
 import java.util.Arrays;
@@ -80,11 +82,55 @@ public class DocsController {
                                                    .saveWordException(calculateSaveWordException())
                                                    .updateWordExampleException(calculateUpdateWordExampleException())
                                                    .deleteWordExampleException(calculateDeleteWordExampleException())
-                                                   .deletePronunciationException(calculateDeletePronunciationException())
+                                                   .deletePronunciationException(
+                                                           calculateDeletePronunciationException())
                                                    .readWordException(calculateReadWordException())
+                                                   .saveCommentException(calculateSaveCommentException())
+                                                   .deleteCommentException(calculateDeleteCommentException())
+                                                   .updateCommentException(calculateUpdateCommentException())
                                                    .build();
 
         return ResponseEntity.ok(new CommonDocsResponse<>(exceptionDocs));
+    }
+
+    private Map<String, ExceptionContent> calculateUpdateCommentException() {
+        Map<String, ExceptionContent> updateCommentException = new LinkedHashMap<>();
+
+        processCommentException(
+                updateCommentException,
+                CommentErrorCode.ASSOCIATION_ACCOUNT_NOT_FOUND,
+                CommentErrorCode.ASSOCIATION_WORD_NOT_FOUND,
+                CommentErrorCode.FORBIDDEN_COMMENT,
+                CommentErrorCode.INVALID_COMMENT_CONTENT
+        );
+
+        return updateCommentException;
+    }
+
+    private Map<String, ExceptionContent> calculateDeleteCommentException() {
+        Map<String, ExceptionContent> deleteCommentException = new LinkedHashMap<>();
+
+        processCommentException(
+                deleteCommentException,
+                CommentErrorCode.ASSOCIATION_ACCOUNT_NOT_FOUND,
+                CommentErrorCode.ASSOCIATION_WORD_NOT_FOUND,
+                CommentErrorCode.FORBIDDEN_COMMENT
+        );
+
+        return deleteCommentException;
+    }
+
+    private Map<String, ExceptionContent> calculateSaveCommentException() {
+        Map<String, ExceptionContent> saveCommentException = new LinkedHashMap<>();
+
+        processCommentException(
+                saveCommentException,
+                CommentErrorCode.ASSOCIATION_ACCOUNT_NOT_FOUND,
+                CommentErrorCode.ASSOCIATION_WORD_NOT_FOUND,
+                CommentErrorCode.INVALID_COMMENT_CONTENT
+        );
+
+        return saveCommentException;
     }
 
     private Map<String, ExceptionContent> calculateReadWordException() {
@@ -260,6 +306,14 @@ public class DocsController {
 
     private void putMethodArgumentNotValidExceptionContent(Map<String, ExceptionContent> target, String... inputs) {
         target.put("INVALID_DATA", createMethodArgumentNotValidExceptionDto(inputs));
+    }
+
+    private void processCommentException(Map<String, ExceptionContent> target, CommentErrorCode... errorCodes) {
+        for (CommentErrorCode errorCode : errorCodes) {
+            ExceptionTranslator translator = CommentExceptionTranslator.findBy(errorCode);
+
+            processExceptionContent(target, translator);
+        }
     }
 
     private void processWordException(Map<String, ExceptionContent> target, WordErrorCode... errorCodes) {

--- a/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/DocsController.java
+++ b/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/DocsController.java
@@ -13,12 +13,14 @@ import com.dnd.spaced.core.word.domain.PronunciationType;
 import com.dnd.spaced.global.exception.code.AccountErrorCode;
 import com.dnd.spaced.global.exception.code.AuthErrorCode;
 import com.dnd.spaced.global.exception.code.CommentErrorCode;
+import com.dnd.spaced.global.exception.code.LikeErrorCode;
 import com.dnd.spaced.global.exception.code.WordErrorCode;
 import com.dnd.spaced.global.exception.response.ExceptionDto;
 import com.dnd.spaced.global.exception.translator.AccountExceptionTranslator;
 import com.dnd.spaced.global.exception.translator.AuthExceptionTranslator;
 import com.dnd.spaced.global.exception.translator.CommentExceptionTranslator;
 import com.dnd.spaced.global.exception.translator.ExceptionTranslator;
+import com.dnd.spaced.global.exception.translator.LikeExceptionTranslator;
 import com.dnd.spaced.global.exception.translator.WordExceptionTranslator;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -88,9 +90,22 @@ public class DocsController {
                                                    .saveCommentException(calculateSaveCommentException())
                                                    .deleteCommentException(calculateDeleteCommentException())
                                                    .updateCommentException(calculateUpdateCommentException())
+                                                   .processLikeException(calculateProcessLikeException())
                                                    .build();
 
         return ResponseEntity.ok(new CommonDocsResponse<>(exceptionDocs));
+    }
+
+    private Map<String, ExceptionContent> calculateProcessLikeException() {
+        Map<String, ExceptionContent> processLikeException = new LinkedHashMap<>();
+
+        processLikeException(
+                processLikeException,
+                LikeErrorCode.FORBIDDEN_LIKE,
+                LikeErrorCode.ASSOCIATION_COMMENT_NOT_FOUND
+        );
+
+        return processLikeException;
     }
 
     private Map<String, ExceptionContent> calculateUpdateCommentException() {
@@ -306,6 +321,14 @@ public class DocsController {
 
     private void putMethodArgumentNotValidExceptionContent(Map<String, ExceptionContent> target, String... inputs) {
         target.put("INVALID_DATA", createMethodArgumentNotValidExceptionDto(inputs));
+    }
+
+    private void processLikeException(Map<String, ExceptionContent> target, LikeErrorCode... errorCodes) {
+        for (LikeErrorCode errorCode : errorCodes) {
+            ExceptionTranslator translator = LikeExceptionTranslator.findBy(errorCode);
+
+            processExceptionContent(target, translator);
+        }
     }
 
     private void processCommentException(Map<String, ExceptionContent> target, CommentErrorCode... errorCodes) {

--- a/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/DocsControllerTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/DocsControllerTest.java
@@ -161,6 +161,24 @@ class DocsControllerTest extends CommonControllerSliceTest {
                                       beneathPath("data.readWordException").withSubsectionId("readWordException"),
                                       attributes(key("title").value("`GET /words/{id}` 예외 상황")),
                                       exceptionConvertFieldDescriptor(data.getReadWordException())
+                              ),
+                              customResponseFields(
+                                      "exception-response",
+                                      beneathPath("data.saveCommentException").withSubsectionId("saveCommentException"),
+                                      attributes(key("title").value("`POST /words/{wordId}/comments` 예외 상황")),
+                                      exceptionConvertFieldDescriptor(data.getSaveCommentException())
+                              ),
+                              customResponseFields(
+                                      "exception-response",
+                                      beneathPath("data.deleteCommentException").withSubsectionId("deleteCommentException"),
+                                      attributes(key("title").value("`DELETE /comments/{id}` 예외 상황")),
+                                      exceptionConvertFieldDescriptor(data.getDeleteCommentException())
+                              ),
+                              customResponseFields(
+                                      "exception-response",
+                                      beneathPath("data.updateCommentException").withSubsectionId("updateCommentException"),
+                                      attributes(key("title").value("`PUT /comments/{id}` 예외 상황")),
+                                      exceptionConvertFieldDescriptor(data.getUpdateCommentException())
                               )
                       )
               );

--- a/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/DocsControllerTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/DocsControllerTest.java
@@ -179,6 +179,12 @@ class DocsControllerTest extends CommonControllerSliceTest {
                                       beneathPath("data.updateCommentException").withSubsectionId("updateCommentException"),
                                       attributes(key("title").value("`PUT /comments/{id}` 예외 상황")),
                                       exceptionConvertFieldDescriptor(data.getUpdateCommentException())
+                              ),
+                              customResponseFields(
+                                      "exception-response",
+                                      beneathPath("data.processLikeException").withSubsectionId("processLikeException"),
+                                      attributes(key("title").value("`POST /comments/{commentId}/likes` 예외 상황")),
+                                      exceptionConvertFieldDescriptor(data.getProcessLikeException())
                               )
                       )
               );

--- a/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/exceptions/ExceptionDocs.java
+++ b/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/exceptions/ExceptionDocs.java
@@ -27,4 +27,5 @@ public class ExceptionDocs {
     private Map<String, ExceptionContent> saveCommentException;
     private Map<String, ExceptionContent> deleteCommentException;
     private Map<String, ExceptionContent> updateCommentException;
+    private Map<String, ExceptionContent> processLikeException;
 }

--- a/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/exceptions/ExceptionDocs.java
+++ b/space-d/src/test/java/com/dnd/spaced/config/docs/snippet/exceptions/ExceptionDocs.java
@@ -24,4 +24,7 @@ public class ExceptionDocs {
     private Map<String, ExceptionContent> deleteWordExampleException;
     private Map<String, ExceptionContent> deletePronunciationException;
     private Map<String, ExceptionContent> readWordException;
+    private Map<String, ExceptionContent> saveCommentException;
+    private Map<String, ExceptionContent> deleteCommentException;
+    private Map<String, ExceptionContent> updateCommentException;
 }

--- a/space-d/src/test/java/com/dnd/spaced/core/account/domain/AccountTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/account/domain/AccountTest.java
@@ -285,6 +285,41 @@ class AccountTest {
         assertThat(actual).isTrue();
     }
 
+    @Test
+    void isEqualTo_메서드는_일치하는_id를_전달하면_true를_반환한다() {
+        // given
+        String id = "email";
+        Account account = Account.builder()
+                                 .id(id)
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+
+        // when
+        boolean actual = account.isEqualTo(id);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void isEqualTo_메서드는_일치하지_않는_id를_전달하면_false를_반환한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("email")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+
+        // when
+        boolean actual = account.isEqualTo("invalidId");
+
+        // then
+        assertThat(actual).isFalse();
+    }
+
     private static Stream<Arguments> builderTestWithInvalidNickname() {
         return Stream.of(
                 Arguments.of((Object) null), Arguments.of(""), Arguments.of("  "),

--- a/space-d/src/test/java/com/dnd/spaced/core/comment/application/CommentServiceTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/comment/application/CommentServiceTest.java
@@ -1,0 +1,380 @@
+package com.dnd.spaced.core.comment.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.dnd.spaced.config.clean.annotation.CleanUpDatabase;
+import com.dnd.spaced.core.account.domain.Account;
+import com.dnd.spaced.core.account.domain.Role;
+import com.dnd.spaced.core.account.domain.repository.AccountRepository;
+import com.dnd.spaced.core.comment.application.dto.response.ReadAllCommentDto;
+import com.dnd.spaced.core.comment.application.exception.AssociationAccountNotFoundException;
+import com.dnd.spaced.core.comment.application.exception.AssociationWordNotFoundException;
+import com.dnd.spaced.core.comment.application.exception.CommentNotFoundException;
+import com.dnd.spaced.core.comment.application.exception.ForbiddenCommentException;
+import com.dnd.spaced.core.comment.domain.exception.InvalidCommentContentException;
+import com.dnd.spaced.core.like.infrastructure.LikeCountRedisRepository;
+import com.dnd.spaced.core.word.domain.Word;
+import com.dnd.spaced.core.word.domain.repository.WordRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SuppressWarnings("NonAsciiCharacters")
+@CleanUpDatabase
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CommentServiceTest {
+
+    @Autowired
+    CommentService commentService;
+
+    @Autowired
+    AccountRepository accountRepository;
+
+    @Autowired
+    WordRepository wordRepository;
+
+    @Autowired
+    LikeCountRedisRepository likeCountRedisRepository;
+
+    @Test
+    void save_메서드는_없는_회원을_전달하면_AssociationAccountNotFoundException_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> commentService.save("accountId", -1L, "댓글"))
+                .isInstanceOf(AssociationAccountNotFoundException.class)
+                .hasMessage("유효하지 않은 회원입니다.");
+    }
+
+    @Test
+    void save_메서드는_지정한_용어_ID가_없다면_AssociationWordNotFoundException_예외가_발생한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+
+        accountRepository.save(account);
+
+        // when & then
+        assertThatThrownBy(() -> commentService.save(account.getId(), -1L, "댓글"))
+                .isInstanceOf(AssociationWordNotFoundException.class)
+                .hasMessage("댓글과 관련된 용어를 찾을 수 없습니다.");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void save_메서드는_유효하지_않은_댓글_내용을_전달하면_InvalidCommentContentException_예외가_발생한다(String invalidContent) {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+        Word word = Word.builder()
+                        .name("Authorization")
+                        .meaning("word meaning")
+                        .categoryName("개발")
+                        .build();
+
+        accountRepository.save(account);
+        wordRepository.save(word);
+
+        // when & then
+        assertThatThrownBy(() -> commentService.save(account.getId(), word.getId(), invalidContent))
+                .isInstanceOf(InvalidCommentContentException.class)
+                .hasMessage("댓글 내용은 최소 1글자 이상, 최소 100글자 이하여야 합니다");
+    }
+
+    @Test
+    void save_메서드는_유효한_파라미터를_전달하면_댓글을_추가한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+        Word word = Word.builder()
+                        .name("Authorization")
+                        .meaning("word meaning")
+                        .categoryName("개발")
+                        .build();
+
+        accountRepository.save(account);
+        wordRepository.save(word);
+
+        // when & then
+        assertDoesNotThrow(() -> commentService.save(account.getId(), word.getId(), "댓글"));
+    }
+
+    @Test
+    void delete_메서드는_없는_회원을_전달하면_AssociationAccountNotFoundException_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> commentService.delete("accountId", -1L))
+                .isInstanceOf(AssociationAccountNotFoundException.class)
+                .hasMessage("유효하지 않은 회원입니다.");
+    }
+
+    @Test
+    void delete_메서드는_지정한_댓글_ID가_없다면_CommentNotFoundException_예외가_발생한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+
+        accountRepository.save(account);
+
+        // when & then
+        assertThatThrownBy(() -> commentService.delete(account.getId(), -1L))
+                .isInstanceOf(CommentNotFoundException.class)
+                .hasMessage("지정한 ID에 해당하는 댓글이 없습니다.");
+    }
+
+    @Test
+    void delete_메서드는_댓글_작성자가_아니라면_ForbiddenCommentException_예외가_발생한다() {
+        // given
+        Account writer = Account.builder()
+                                .id("accountId1")
+                                .nickname("nickname")
+                                .profileImage("profileImage")
+                                .roleName(Role.ROLE_ADMIN.name())
+                                .build();
+        Word word = Word.builder()
+                        .name("Authorization")
+                        .meaning("word meaning")
+                        .categoryName("개발")
+                        .build();
+        Account account = Account.builder()
+                                 .id("accountId2")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+
+        accountRepository.save(writer);
+        accountRepository.save(account);
+        wordRepository.save(word);
+        commentService.save(writer.getId(), word.getId(), "댓글");
+
+        // when & then
+        assertThatThrownBy(() -> commentService.delete(account.getId(), 1L))
+                .isInstanceOf(ForbiddenCommentException.class)
+                .hasMessage("댓글을 삭제할 권한이 없습니다.");
+    }
+
+    @Test
+    void delete_메서드는_유효한_파라미터를_전달하면_지정한_댓글을_싹제한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId1")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+        Word word = Word.builder()
+                        .name("Authorization")
+                        .meaning("word meaning")
+                        .categoryName("개발")
+                        .build();
+
+        accountRepository.save(account);
+        wordRepository.save(word);
+        commentService.save(account.getId(), word.getId(), "댓글");
+
+        // when & then
+        assertDoesNotThrow(() -> commentService.delete(account.getId(), 1L));
+    }
+
+    @Test
+    void update_메서드는_없는_회원을_전달하면_AssociationAccountNotFoundException_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> commentService.update("accountId", -1L, "댓글"))
+                .isInstanceOf(AssociationAccountNotFoundException.class)
+                .hasMessage("유효하지 않은 회원입니다.");
+    }
+
+    @Test
+    void update_메서드는_지정한_댓글_ID가_없다면_CommentNotFoundException_예외가_발생한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+
+        accountRepository.save(account);
+
+        // when & then
+        assertThatThrownBy(() -> commentService.update(account.getId(), -1L, "댓글"))
+                .isInstanceOf(CommentNotFoundException.class)
+                .hasMessage("지정한 ID에 해당하는 댓글이 없습니다.");
+    }
+
+    @Test
+    void update_메서드는_댓글_작성자가_아니라면_ForbiddenCommentException_예외가_발생한다() {
+        // given
+        Account writer = Account.builder()
+                                .id("accountId1")
+                                .nickname("nickname")
+                                .profileImage("profileImage")
+                                .roleName(Role.ROLE_ADMIN.name())
+                                .build();
+        Word word = Word.builder()
+                        .name("Authorization")
+                        .meaning("word meaning")
+                        .categoryName("개발")
+                        .build();
+        Account account = Account.builder()
+                                 .id("accountId2")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+
+        accountRepository.save(writer);
+        accountRepository.save(account);
+        wordRepository.save(word);
+        commentService.save(writer.getId(), word.getId(), "댓글");
+
+        // when & then
+        assertThatThrownBy(() -> commentService.update(account.getId(), 1L, "댓글"))
+                .isInstanceOf(ForbiddenCommentException.class)
+                .hasMessage("댓글을 수정할 권한이 없습니다.");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void update_메서드는_유효하지_않은_댓글_내용을_전달하면_InvalidCommentContentException_예외가_발생한다(String invalidContent) {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+        Word word = Word.builder()
+                        .name("Authorization")
+                        .meaning("word meaning")
+                        .categoryName("개발")
+                        .build();
+
+        accountRepository.save(account);
+        wordRepository.save(word);
+        commentService.save(account.getId(), word.getId(), "댓글");
+
+        // when & then
+        assertThatThrownBy(() -> commentService.update(account.getId(), word.getId(), invalidContent))
+                .isInstanceOf(InvalidCommentContentException.class)
+                .hasMessage("댓글 내용은 최소 1글자 이상, 최소 100글자 이하여야 합니다");
+    }
+
+    @Test
+    void update_메서드는_유효한_파라미터를_전달하면_전달한_내용으로_댓글_내용을_변경한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId1")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+        Word word = Word.builder()
+                        .name("Authorization")
+                        .meaning("word meaning")
+                        .categoryName("개발")
+                        .build();
+
+        accountRepository.save(account);
+        wordRepository.save(word);
+        commentService.save(account.getId(), word.getId(), "댓글");
+
+        // when & then
+        assertDoesNotThrow(() -> commentService.update(account.getId(), 1L, "댓글 변경"));
+    }
+
+    @Test
+    void readAllBy_메서드는_로그인한_경우_지정한_조건에_따라_댓글_목록을_조회한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId1")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+        Word word = Word.builder()
+                        .name("Authorization")
+                        .meaning("word meaning")
+                        .categoryName("개발")
+                        .build();
+
+        accountRepository.save(account);
+        wordRepository.save(word);
+        commentService.save(account.getId(), word.getId(), "댓글");
+
+        // when
+        List<ReadAllCommentDto> actual = commentService.readAllBy(
+                null,
+                word.getId(),
+                null,
+                PageRequest.of(0, 10)
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(actual).hasSize(1),
+                () -> assertThat(actual.get(0).commentInfo().content()).isEqualTo("댓글")
+        );
+    }
+
+    @Test
+    void readAllBy_메서드는_로그인하지_않은_경우_지정한_조건에_따라_댓글_목록을_조회한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId1")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+        Word word = Word.builder()
+                        .name("Authorization")
+                        .meaning("word meaning")
+                        .categoryName("개발")
+                        .build();
+
+        accountRepository.save(account);
+        wordRepository.save(word);
+        commentService.save(account.getId(), word.getId(), "댓글");
+
+        // when
+        List<ReadAllCommentDto> actual = commentService.readAllBy(
+                account.getId(),
+                word.getId(),
+                null,
+                PageRequest.of(0, 10)
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(actual).hasSize(1),
+                () -> assertThat(actual.get(0).commentInfo().content()).isEqualTo("댓글")
+        );
+    }
+}

--- a/space-d/src/test/java/com/dnd/spaced/core/comment/domain/CommentTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/comment/domain/CommentTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.dnd.spaced.core.account.domain.Account;
+import com.dnd.spaced.core.account.domain.Role;
 import com.dnd.spaced.core.comment.domain.exception.InvalidCommentContentException;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -33,10 +35,16 @@ class CommentTest {
     @Test
     void isOnwer_메서드는_accountId를_전달하면_해당_Comment의_작성자인지_여부를_반환한다() {
         // given
-        Comment comment = new Comment("accountId", 1L, "댓글");
+        Account account = Account.builder()
+                                 .id("accountId")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+        Comment comment = new Comment(account.getId(), 1L, "댓글");
 
         // when
-        boolean actual = comment.isOwner(comment.getAccountId());
+        boolean actual = comment.isOwner(account);
 
         // then
         assertThat(actual).isTrue();

--- a/space-d/src/test/java/com/dnd/spaced/core/comment/domain/CommentTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/comment/domain/CommentTest.java
@@ -1,0 +1,71 @@
+package com.dnd.spaced.core.comment.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.dnd.spaced.core.comment.domain.exception.InvalidCommentContentException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CommentTest {
+
+    @Test
+    void 생성자는_유효한_accountId_wordId_content를_전달하면_Comment를_초기화하고_반환한다() {
+        // when & then
+        assertDoesNotThrow(() -> new Comment("accountId", 1L, "댓글"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void 생성자는_유효하지_않은_content를_전달하면_InvalidCommentContentException_예외가_발생한다(String invalidContent) {
+        // when & then
+        assertThatThrownBy(() -> new Comment("accountId", 1L, invalidContent))
+                .isInstanceOf(InvalidCommentContentException.class)
+                .hasMessage("댓글 내용은 최소 1글자 이상, 최소 100글자 이하여야 합니다");
+    }
+
+    @Test
+    void isOnwer_메서드는_accountId를_전달하면_해당_Comment의_작성자인지_여부를_반환한다() {
+        // given
+        Comment comment = new Comment("accountId", 1L, "댓글");
+
+        // when
+        boolean actual = comment.isOwner(comment.getAccountId());
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    void changeContent_메서드는_유효한_accountId_wordId_content를_전달하면_Comment를_초기화하고_반환한다() {
+        // given
+        Comment comment = new Comment("accountId", 1L, "댓글");
+
+        // when
+        String changedContent = "변경";
+
+        comment.changeContent(changedContent);
+
+        // when & then
+        assertThat(comment.getContent()).isEqualTo(changedContent);
+
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void changeContent_메서드는_유효하지_않은_content를_전달하면_InvalidCommentContentException_예외가_발생한다(String invalidContent) {
+        // given
+        Comment comment = new Comment("accountId", 1L, "댓글");
+
+        // when & then
+        assertThatThrownBy(() -> comment.changeContent(invalidContent))
+                .isInstanceOf(InvalidCommentContentException.class)
+                .hasMessage("댓글 내용은 최소 1글자 이상, 최소 100글자 이하여야 합니다");
+    }
+}

--- a/space-d/src/test/java/com/dnd/spaced/core/comment/domain/LikeTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/comment/domain/LikeTest.java
@@ -1,0 +1,19 @@
+package com.dnd.spaced.core.comment.domain;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.dnd.spaced.core.like.domain.Like;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LikeTest {
+
+    @Test
+    void 생성자는_accountId와_commentId를_전달하면_Like를_초기화하고_반환한다() {
+        // when & then
+        assertDoesNotThrow(() -> new Like("accountId", 1L));
+    }
+}

--- a/space-d/src/test/java/com/dnd/spaced/core/comment/presentation/CommentControllerTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/comment/presentation/CommentControllerTest.java
@@ -6,6 +6,10 @@ import static org.mockito.BDDMockito.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -26,7 +30,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -41,7 +44,7 @@ class CommentControllerTest extends CommonControllerSliceTest {
 
         // when & then
         ResultActions resultActions = mockMvc.perform(
-                RestDocumentationRequestBuilders.post("/words/{wordId}/comments", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
+                post("/words/{wordId}/comments", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
                                                 .contentType(MediaType.APPLICATION_JSON)
                                                 .content(objectMapper.writeValueAsString(request))
         ).andExpectAll(
@@ -73,7 +76,7 @@ class CommentControllerTest extends CommonControllerSliceTest {
     void delete_성공_테스트() throws Exception {
         // when & then
         ResultActions resultActions = mockMvc.perform(
-                RestDocumentationRequestBuilders.delete("/comments/{id}", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
+                delete("/comments/{id}", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
         ).andExpectAll(
                 status().isNoContent()
         );
@@ -102,7 +105,7 @@ class CommentControllerTest extends CommonControllerSliceTest {
 
         // when & then
         ResultActions resultActions = mockMvc.perform(
-                RestDocumentationRequestBuilders.put("/comments/{id}", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
+                put("/comments/{id}", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
                                          .contentType(MediaType.APPLICATION_JSON)
                                          .content(objectMapper.writeValueAsString(request))
         ).andExpectAll(
@@ -139,7 +142,7 @@ class CommentControllerTest extends CommonControllerSliceTest {
 
         // when & then
         ResultActions resultActions = mockMvc.perform(
-                RestDocumentationRequestBuilders.get("/words/{wordId}/comments", 1L).accept(MediaType.APPLICATION_JSON)
+                get("/words/{wordId}/comments", 1L).accept(MediaType.APPLICATION_JSON)
         ).andExpectAll(
                 status().isOk(),
                 jsonPath("comments").exists(),

--- a/space-d/src/test/java/com/dnd/spaced/core/comment/presentation/CommentControllerTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/comment/presentation/CommentControllerTest.java
@@ -1,0 +1,99 @@
+package com.dnd.spaced.core.comment.presentation;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dnd.spaced.config.common.CommonControllerSliceTest;
+import com.dnd.spaced.core.comment.application.dto.response.ReadAllCommentDto;
+import com.dnd.spaced.core.comment.application.dto.response.ReadAllCommentDto.CommentInfoDto;
+import com.dnd.spaced.core.comment.application.dto.response.ReadAllCommentDto.WriterInfoDto;
+import com.dnd.spaced.core.comment.presentation.dto.request.SaveCommentRequest;
+import com.dnd.spaced.core.comment.presentation.dto.request.UpdateCommentRequest;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@SuppressWarnings("NonAsciiCharacters")
+class CommentControllerTest extends CommonControllerSliceTest {
+
+    @Test
+    @WithMockUser("account")
+    void save_성공_테스트() throws Exception {
+        // given
+        SaveCommentRequest request = new SaveCommentRequest("content");
+
+        // when & then
+        mockMvc.perform(
+                post("/words/{wordId}/comments", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
+                                                    .contentType(MediaType.APPLICATION_JSON)
+                                                    .content(objectMapper.writeValueAsString(request))
+        ).andExpectAll(
+                status().isCreated(),
+                header().string("Location", "/words/1")
+        );
+    }
+
+    @Test
+    @WithMockUser("account")
+    void delete_성공_테스트() throws Exception {
+        // when & then
+        mockMvc.perform(
+                delete("/comments/{id}", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
+        ).andExpectAll(
+                status().isNoContent()
+        );
+    }
+
+    @Test
+    @WithMockUser("account")
+    void update_성공_테스트() throws Exception {
+        // given
+        UpdateCommentRequest request = new UpdateCommentRequest("change content");
+
+        // when & then
+        mockMvc.perform(
+                put("/comments/{id}", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
+                                                    .contentType(MediaType.APPLICATION_JSON)
+                                                    .content(objectMapper.writeValueAsString(request))
+        ).andExpectAll(
+                status().isNoContent()
+        );
+    }
+
+    @Test
+    void readAllBy_성공_테스트() throws Exception {
+        // given
+        CommentInfoDto commentInfoDto = new CommentInfoDto(1L, 1L, "content", 0);
+        WriterInfoDto writerInfoDto = new WriterInfoDto("accountId", "writer", "profileImage");
+        ReadAllCommentDto readAllCommentDto = new ReadAllCommentDto(commentInfoDto, writerInfoDto, false);
+
+        given(commentService.readAllBy(eq(null), anyLong(), eq(null), any())).willReturn(List.of(readAllCommentDto));
+
+        // when & then
+        mockMvc.perform(
+                get("/words/{wordId}/comments", 1L).accept(MediaType.APPLICATION_JSON)
+        ).andExpectAll(
+                status().isOk(),
+                jsonPath("comments").exists(),
+                jsonPath("comments[*].commentInfo").exists(),
+                jsonPath("comments[*].commentInfo.id").exists(),
+                jsonPath("comments[*].commentInfo.content").value("content"),
+                jsonPath("comments[*].commentInfo.likeCount").value(0),
+                jsonPath("comments[*].writerInfo").exists(),
+                jsonPath("comments[*].writerInfo.id").value("accountId"),
+                jsonPath("comments[*].writerInfo.writerNickname").value("writer"),
+                jsonPath("comments[*].writerInfo.writerProfileImage").value("profileImage")
+        );
+    }
+}

--- a/space-d/src/test/java/com/dnd/spaced/core/comment/presentation/CommentControllerTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/comment/presentation/CommentControllerTest.java
@@ -4,10 +4,14 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -22,7 +26,9 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.ResultActions;
 
 @SuppressWarnings("NonAsciiCharacters")
 class CommentControllerTest extends CommonControllerSliceTest {
@@ -34,13 +40,31 @@ class CommentControllerTest extends CommonControllerSliceTest {
         SaveCommentRequest request = new SaveCommentRequest("content");
 
         // when & then
-        mockMvc.perform(
-                post("/words/{wordId}/comments", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
-                                                    .contentType(MediaType.APPLICATION_JSON)
-                                                    .content(objectMapper.writeValueAsString(request))
+        ResultActions resultActions = mockMvc.perform(
+                RestDocumentationRequestBuilders.post("/words/{wordId}/comments", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
+                                                .contentType(MediaType.APPLICATION_JSON)
+                                                .content(objectMapper.writeValueAsString(request))
         ).andExpectAll(
                 status().isCreated(),
                 header().string("Location", "/words/1")
+        );
+
+        save_문서화(resultActions);
+    }
+
+    private void save_문서화(ResultActions resultActions) throws Exception {
+        resultActions.andDo(
+                restDocs.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("Bearer 타입의 Access Token")
+                        ),
+                        pathParameters(
+                                parameterWithName("wordId").description("댓글을 추가할 용어 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").description("댓글 내용")
+                        )
+                )
         );
     }
 
@@ -48,10 +72,25 @@ class CommentControllerTest extends CommonControllerSliceTest {
     @WithMockUser("account")
     void delete_성공_테스트() throws Exception {
         // when & then
-        mockMvc.perform(
-                delete("/comments/{id}", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
+        ResultActions resultActions = mockMvc.perform(
+                RestDocumentationRequestBuilders.delete("/comments/{id}", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
         ).andExpectAll(
                 status().isNoContent()
+        );
+
+        delete_문서화(resultActions);
+    }
+
+    private void delete_문서화(ResultActions resultActions) throws Exception {
+        resultActions.andDo(
+                restDocs.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("Bearer 타입의 Access Token")
+                        ),
+                        pathParameters(
+                                parameterWithName("id").description("삭제할 댓글 ID")
+                        )
+                )
         );
     }
 
@@ -62,12 +101,30 @@ class CommentControllerTest extends CommonControllerSliceTest {
         UpdateCommentRequest request = new UpdateCommentRequest("change content");
 
         // when & then
-        mockMvc.perform(
-                put("/comments/{id}", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
-                                                    .contentType(MediaType.APPLICATION_JSON)
-                                                    .content(objectMapper.writeValueAsString(request))
+        ResultActions resultActions = mockMvc.perform(
+                RestDocumentationRequestBuilders.put("/comments/{id}", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
+                                         .contentType(MediaType.APPLICATION_JSON)
+                                         .content(objectMapper.writeValueAsString(request))
         ).andExpectAll(
                 status().isNoContent()
+        );
+
+        update_문서화(resultActions);
+    }
+
+    private void update_문서화(ResultActions resultActions) throws Exception {
+        resultActions.andDo(
+                restDocs.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("Bearer 타입의 Access Token")
+                        ),
+                        pathParameters(
+                                parameterWithName("id").description("수정할 댓글 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").description("수정할 댓글 내용")
+                        )
+                )
         );
     }
 
@@ -81,8 +138,8 @@ class CommentControllerTest extends CommonControllerSliceTest {
         given(commentService.readAllBy(eq(null), anyLong(), eq(null), any())).willReturn(List.of(readAllCommentDto));
 
         // when & then
-        mockMvc.perform(
-                get("/words/{wordId}/comments", 1L).accept(MediaType.APPLICATION_JSON)
+        ResultActions resultActions = mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/words/{wordId}/comments", 1L).accept(MediaType.APPLICATION_JSON)
         ).andExpectAll(
                 status().isOk(),
                 jsonPath("comments").exists(),
@@ -94,6 +151,36 @@ class CommentControllerTest extends CommonControllerSliceTest {
                 jsonPath("comments[*].writerInfo.id").value("accountId"),
                 jsonPath("comments[*].writerInfo.writerNickname").value("writer"),
                 jsonPath("comments[*].writerInfo.writerProfileImage").value("profileImage")
+        );
+
+        readAllBy_문서화(resultActions);
+    }
+
+    private void readAllBy_문서화(ResultActions resultActions) throws Exception {
+        resultActions.andDo(
+                restDocs.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("Bearer 타입의 Access Token").optional()
+                        ),
+                        pathParameters(
+                                parameterWithName("wordId").description("댓글 목록을 조회할 용어 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("lastCommentId").description("마지막으로 조회한 댓글 ID").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("comments").description("댓글 목록 조회 결과"),
+                                fieldWithPath("comments[*].commentInfo").description("댓글 정보"),
+                                fieldWithPath("comments[*].commentInfo.id").description("댓글 ID"),
+                                fieldWithPath("comments[*].commentInfo.wordId").description("댓글이 추가된 용어 ID"),
+                                fieldWithPath("comments[*].commentInfo.content").description("댓글 내용"),
+                                fieldWithPath("comments[*].commentInfo.likeCount").description("댓글 좋아요 수"),
+                                fieldWithPath("comments[*].writerInfo").description("작성자 정보"),
+                                fieldWithPath("comments[*].writerInfo.id").description("작성자 ID"),
+                                fieldWithPath("comments[*].writerInfo.writerNickname").description("작성자 닉네임"),
+                                fieldWithPath("comments[*].writerInfo.writerProfileImage").description("작성자 프로필 이미지")
+                        )
+                )
         );
     }
 }

--- a/space-d/src/test/java/com/dnd/spaced/core/like/application/LikeServiceTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/like/application/LikeServiceTest.java
@@ -1,0 +1,137 @@
+package com.dnd.spaced.core.like.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.dnd.spaced.config.clean.annotation.CleanUpPersistence;
+import com.dnd.spaced.core.account.domain.Account;
+import com.dnd.spaced.core.account.domain.Role;
+import com.dnd.spaced.core.account.domain.repository.AccountRepository;
+import com.dnd.spaced.core.comment.domain.Comment;
+import com.dnd.spaced.core.comment.domain.repository.CommentRepository;
+import com.dnd.spaced.core.like.application.exception.AssociationCommentNotFoundException;
+import com.dnd.spaced.core.like.application.exception.ForbiddenLikeException;
+import com.dnd.spaced.core.like.domain.Like;
+import com.dnd.spaced.core.like.domain.repository.LikeRepository;
+import com.dnd.spaced.core.word.domain.Word;
+import com.dnd.spaced.core.word.domain.repository.WordRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SuppressWarnings("NonAsciiCharacters")
+@CleanUpPersistence
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LikeServiceTest {
+
+    @Autowired
+    LikeService likeService;
+
+    @Autowired
+    AccountRepository accountRepository;
+
+    @Autowired
+    WordRepository wordRepository;
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @Autowired
+    LikeRepository likeRepository;
+
+    @Test
+    void processLike_메서드는_없는_회원을_전달하면_ForbiddenLikeException_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> likeService.processLike("accountId", -1L))
+                .isInstanceOf(ForbiddenLikeException.class)
+                .hasMessage("좋아요를 제어할 권한이 없습니다.");
+    }
+
+    @Test
+    void processLike_메서드는_없는_댓글을_전달하면_AssociationCommentNotFoundException_예외가_발생한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+
+        accountRepository.save(account);
+
+        // when & then
+        assertThatThrownBy(() -> likeService.processLike(account.getId(), -1L))
+                .isInstanceOf(AssociationCommentNotFoundException.class)
+                .hasMessage("좋아요 대상인 댓글을 찾을 수 없습니다.");
+    }
+
+    @Test
+    void processLike_메서드는_이미_좋아요를_수행한_댓글인_경우_좋아요를_삭제한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+        Word word = Word.builder()
+                        .name("Authorization")
+                        .meaning("word meaning")
+                        .categoryName("개발")
+                        .build();
+
+        accountRepository.save(account);
+        wordRepository.save(word);
+
+        Comment comment = new Comment(account.getId(), word.getId(), "댓글");
+
+        commentRepository.save(comment);
+        likeService.processLike(account.getId(), comment.getId());
+
+        // when
+        likeService.processLike(account.getId(), comment.getId());
+
+        // then
+        Optional<Like> actual = likeRepository.findBy(account.getId(), comment.getId());
+
+        assertThat(actual).isEmpty();
+    }
+
+    @Test
+    void processLike_메서드는_좋아요를_하지_않은_댓글의_경우_좋아요를_수행한다() {
+        // given
+        Account account = Account.builder()
+                                 .id("accountId")
+                                 .nickname("nickname")
+                                 .profileImage("profileImage")
+                                 .roleName(Role.ROLE_ADMIN.name())
+                                 .build();
+        Word word = Word.builder()
+                        .name("Authorization")
+                        .meaning("word meaning")
+                        .categoryName("개발")
+                        .build();
+
+        accountRepository.save(account);
+        wordRepository.save(word);
+
+        Comment comment = new Comment(account.getId(), word.getId(), "댓글");
+
+        commentRepository.save(comment);
+
+        // when
+        likeService.processLike(account.getId(), comment.getId());
+
+        // then
+        Optional<Like> actual = likeRepository.findBy(account.getId(), comment.getId());
+
+        assertThat(actual).isPresent();
+    }
+}

--- a/space-d/src/test/java/com/dnd/spaced/core/like/presentation/LikeControllerTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/like/presentation/LikeControllerTest.java
@@ -1,0 +1,24 @@
+package com.dnd.spaced.core.like.presentation;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.dnd.spaced.config.common.CommonControllerSliceTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.test.context.support.WithMockUser;
+
+@SuppressWarnings("NonAsciiCharacters")
+class LikeControllerTest extends CommonControllerSliceTest {
+
+    @Test
+    @WithMockUser("account")
+    void processLike_성공_테스트() throws Exception {
+        // when & then
+        mockMvc.perform(
+                post("/comments/{commentId}/likes", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
+        ).andExpectAll(
+                status().isNoContent()
+        );
+    }
+}

--- a/space-d/src/test/java/com/dnd/spaced/core/like/presentation/LikeControllerTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/like/presentation/LikeControllerTest.java
@@ -1,12 +1,17 @@
 package com.dnd.spaced.core.like.presentation;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dnd.spaced.config.common.CommonControllerSliceTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.ResultActions;
 
 @SuppressWarnings("NonAsciiCharacters")
 class LikeControllerTest extends CommonControllerSliceTest {
@@ -15,10 +20,25 @@ class LikeControllerTest extends CommonControllerSliceTest {
     @WithMockUser("account")
     void processLike_성공_테스트() throws Exception {
         // when & then
-        mockMvc.perform(
+        ResultActions resultActions = mockMvc.perform(
                 post("/comments/{commentId}/likes", 1L).header(HttpHeaders.AUTHORIZATION, "Bearer AccessToken")
         ).andExpectAll(
                 status().isNoContent()
+        );
+
+        processLike_문서화(resultActions);
+    }
+
+    private void processLike_문서화(ResultActions resultActions) throws Exception {
+        resultActions.andDo(
+                restDocs.document(
+                        requestHeaders(
+                                headerWithName("Authorization").description("Bearer 타입의 Access Token")
+                        ),
+                        pathParameters(
+                                parameterWithName("commentId").description("좋아요 추가/취소를 수소할 댓글 ID")
+                        )
+                )
         );
     }
 }

--- a/space-d/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
+++ b/space-d/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
@@ -1,10 +1,9 @@
 |===
-|이름|필수여부|설명
+|이름|설명
 
-{{#headers}}
+{{#parameters}}
 |{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
-|{{#tableCellContent}}{{^optional}}true{{/optional}}{{#optional}}false{{/optional}}{{/tableCellContent}}
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
 
-{{/headers}}
+{{/parameters}}
 |===


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #15 
## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->
- 댓글 목록 조회
- 댓글 추가
- 댓글 삭제
- 댓글 수정
- 댓글 좋아요
## 🙋🏻 주의 깊게 확인해야 하는 코드
<!-- (선택) 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
- 조인을 줄이기 위해 댓글에 좋아요 개수를 관리 
- write-back 방식으로 redis에 좋아요 개수를 캐싱하고, 30분 간격으로 스케쥴링해 좋아요 개수 최신화
  - 좋아요 개수가 변경될 때 마다 캐싱이 업데이트되면 비효율적이기 때문에 메모리에서 좋아요 개수를 관리하다가, 일정 개수가 넘어가면 캐시에 업데이트
## 📄 개선 사항 OR 참고 사항
<!-- (선택) 해당 PR에서 개선했거나, 참고 사항이 있다면 설명해주세요. -->
- 댓글과 좋아요를 별도의 패키지로 분리 
- path parameters snippet 포맷 변경
- 회원 도메인에 id만으로 일치 여부를 반환하는 메서드 추가