### PR TITLE
애플리케이션 종료 시 메모리에 있는 버퍼를 redis로 flush하는 기능 추가

### DIFF
--- a/space-d/src/main/java/com/dnd/spaced/core/like/application/event/LikeCountBufferGracefulShutdownListener.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/application/event/LikeCountBufferGracefulShutdownListener.java
@@ -10,7 +10,6 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class LikeCountBufferGracefulShutdownListener implements ApplicationListener<ContextClosedEvent> {

--- a/space-d/src/main/java/com/dnd/spaced/core/like/application/event/LikeCountBufferGracefulShutdownListener.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/application/event/LikeCountBufferGracefulShutdownListener.java
@@ -1,0 +1,32 @@
+package com.dnd.spaced.core.like.application.event;
+
+import com.dnd.spaced.core.like.infrastructure.LikeCountRedisRepository;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LikeCountBufferGracefulShutdownListener implements ApplicationListener<ContextClosedEvent> {
+
+    private static final long SHUTDOWN_TIMEOUT_SECOND = 60;
+
+    private final LikeCountRedisRepository likeCountRedisRepository;
+
+    @Override
+    public void onApplicationEvent(ContextClosedEvent ignored) {
+        CompletableFuture<Void> shutdownFuture = CompletableFuture.runAsync(
+                                                                          likeCountRedisRepository::flushBuffer,
+                                                                          Executors.newCachedThreadPool()
+                                                                  )
+                                                                  .orTimeout(SHUTDOWN_TIMEOUT_SECOND, TimeUnit.SECONDS);
+
+        shutdownFuture.join();
+    }
+}

--- a/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeCountBuffer.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeCountBuffer.java
@@ -32,7 +32,7 @@ public class LikeCountBuffer {
                      .merge(identifier, -1, Integer::sum);
     }
 
-    private void flushBuffer() {
+    public void flushBuffer() {
         Map<LikeCountIdentifier, Integer> buffer = currentBuffer.getAndSet(new ConcurrentHashMap<>());
 
         CompletableFuture.runAsync(() -> cacheUpdateCallback.accept(buffer), asyncCommentLikeCountExecutor);

--- a/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeCountRedisRepository.java
+++ b/space-d/src/main/java/com/dnd/spaced/core/like/infrastructure/LikeCountRedisRepository.java
@@ -78,6 +78,10 @@ public class LikeCountRedisRepository implements LikeCountRepository {
         buffer.deleteLikeCount(new LikeCountIdentifier(wordId, commentId));
     }
 
+    public void flushBuffer() {
+        buffer.flushBuffer();
+    }
+
     private String calculateKey(Long wordId) {
         return KEY + wordId;
     }


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #26 
## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->
- `ApplicationListener<ContextClosedEvent>`를 활용해 graceful shutdown 시 좋아요 개수 버퍼를 flush하도록 EventListener 추가
## 🙋🏻 주의 깊게 확인해야 하는 코드
<!-- (선택) 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
x
## 📄 개선 사항 OR 참고 사항
<!-- (선택) 해당 PR에서 개선했거나, 참고 사항이 있다면 설명해주세요. -->
- 참고 사항
  - 종료 작업과 겹치지 않도록 별도의 스레드 풀에서 실행
    - 간단한 작업이라고 판단했으므로 Executors.newCachedThreadPool() 사용
  - 시간 제한의 경우 메모리에 저장되며 개수가 크지 않으므로 60초로 설정