### PR TITLE
모니터링 설정 변경

### DIFF
--- a/space-d/src/main/java/com/dnd/spaced/global/config/SecurityConfig.java
+++ b/space-d/src/main/java/com/dnd/spaced/global/config/SecurityConfig.java
@@ -22,12 +22,15 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -61,6 +64,9 @@ public class SecurityConfig {
     @Value("${management.endpoints.web.base-path}")
     private String actuatorPath;
 
+    @Value("${spring.security.user.roles}")
+    private String actuatorRole;
+
     private final ObjectMapper objectMapper;
     private final TokenDecoder tokenDecoder;
     private final CorsProperties corsProperties;
@@ -80,6 +86,24 @@ public class SecurityConfig {
     }
 
     @Bean
+    @Order(1)
+    public SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .securityMatcher(actuatorPath + "/**")
+                .authorizeHttpRequests(auth ->
+                        auth.requestMatchers(
+                                EndpointRequest.to("health", "info", "metrics", "prometheus")
+                            )
+                            .hasRole(actuatorRole)
+                            .anyRequest().denyAll()
+                )
+                .httpBasic(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
             .httpBasic(AbstractHttpConfigurer::disable)
@@ -93,7 +117,6 @@ public class SecurityConfig {
                     .requestMatchers(HttpMethod.GET, "/today-quizzes/{todayQuizId}").permitAll()
                     .requestMatchers(HttpMethod.GET, "/images/{imageName}").permitAll()
                     .requestMatchers(HttpMethod.GET, "/words/{wordId}/comments").permitAll()
-                    .requestMatchers(HttpMethod.GET, actuatorPath + "/**").permitAll()
                     .requestMatchers("/admin/**").hasRole("ADMIN")
                     .anyRequest().authenticated()
             )

--- a/space-d/src/main/resources/application-local.yml
+++ b/space-d/src/main/resources/application-local.yml
@@ -25,6 +25,11 @@ spring:
     open-in-view: false
 
   security:
+    user:
+      name: prometheus
+      password: prometheus_secret_password
+      roles: prometheus
+
     oauth2:
       client:
         registration:

--- a/space-d/src/test/resources/application.yml
+++ b/space-d/src/test/resources/application.yml
@@ -22,6 +22,11 @@ spring:
     open-in-view: false
 
   security:
+    user:
+      name: prometheus
+      password: prometheus_secret_password
+      roles: prometheus
+
     oauth2:
       client:
         registration:


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #129 
## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->
- 서브 모듈 갱신 
- actuator 엔드포인트 접근 시 인증이 필요하도록 변경 
## 🙋🏻 주의 깊게 확인해야 하는 코드
<!-- (선택) 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 📄 개선 사항 OR 참고 사항
<!-- (선택) 해당 PR에서 개선했거나, 참고 사항이 있다면 설명해주세요. -->
- actuator 인증의 경우 basic으로 설정
  - jwt를 활용한 bearer 방식의 경우 매번 프로메테우스 설정 변경이 필요함
  - bearer 방식을 사용하기 위해 별도의 애플리케이션으로 인증하는 것은 비효율적이라고 판단해 basic 방식 사용