### PR TITLE
용어 삭제 관련 테스트 케이스 추가

### DIFF
--- a/space-d/src/test/java/com/dnd/spaced/core/admin/application/event/listener/AdminWordDeleteEventIntegrationTest.java
+++ b/space-d/src/test/java/com/dnd/spaced/core/admin/application/event/listener/AdminWordDeleteEventIntegrationTest.java
@@ -1,0 +1,127 @@
+package com.dnd.spaced.core.admin.application.event.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import com.dnd.spaced.core.admin.application.AdminWordServiceFacade;
+import com.dnd.spaced.core.admin.application.event.dto.DeletedWordEvent;
+import com.dnd.spaced.core.word.application.repository.DeletedWordIdRepository;
+import com.dnd.spaced.core.word.domain.repository.PronunciationRepository;
+import com.dnd.spaced.core.word.domain.repository.WordExampleRepository;
+import com.dnd.spaced.core.word.domain.repository.WordRepository;
+import com.dnd.spaced.fixture.LocalDateTimeFixture;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.IllegalTransactionStateException;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@RecordApplicationEvents
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AdminWordDeleteEventIntegrationTest {
+
+    private static final Long WORD_ID = 1L;
+    private static final long WORD_EXAMPLE_COUNT = 2L;
+    private static final long PRONUNCIATION_COUNT = 2L;
+    private static final LocalDateTime FAR_FUTURE = LocalDateTimeFixture.from("2999-12-31 23:59:59");
+
+    @Autowired
+    AdminWordServiceFacade adminWordServiceFacade;
+
+    @Autowired
+    ApplicationEventPublisher applicationEventPublisher;
+
+    @Autowired
+    TransactionTemplate transactionTemplate;
+
+    @Autowired
+    ApplicationEvents events;
+
+    @Autowired
+    WordRepository wordRepository;
+
+    @Autowired
+    WordExampleRepository wordExampleRepository;
+
+    @Autowired
+    PronunciationRepository pronunciationRepository;
+
+    @Autowired
+    DeletedWordIdRepository deletedWordIdRepository;
+
+    @Test
+    @Sql(scripts = {
+            "classpath:sql/admin/word/word_metadata.sql",
+            "classpath:sql/admin/word/word.sql"
+    })
+    void 외부_트랜잭션이_있다면_용어_삭제_이벤트를_처리하고_전체를_커밋한다() {
+        // when
+        transactionTemplate.executeWithoutResult(status -> adminWordServiceFacade.deleteWord(WORD_ID));
+
+        // then
+        assertAll(
+                () -> assertThat(events.stream(DeletedWordEvent.class).count()).isOne(),
+                () -> assertThat(wordRepository.existsBy(WORD_ID)).isFalse(),
+                () -> assertThat(wordExampleRepository.countBy(WORD_ID)).isZero(),
+                () -> assertThat(pronunciationRepository.countBy(WORD_ID)).isZero(),
+                () -> assertThat(deletedWordIdRepository.findAllBy(FAR_FUTURE)).contains(WORD_ID)
+        );
+    }
+
+    @Test
+    @Sql(scripts = {
+            "classpath:sql/admin/word/word_metadata.sql",
+            "classpath:sql/admin/word/word.sql"
+    })
+    void 외부_트랜잭션이_있고_용어_삭제_이벤트_처리중_예외가_발생하면_전체를_롤백한다() {
+        // given
+        doThrow(DataAccessResourceFailureException.class).when(deletedWordIdRepository)
+                                                         .save(anyLong(), any(LocalDateTime.class));
+
+        // when & then
+        assertThatThrownBy(() -> transactionTemplate.executeWithoutResult(status -> adminWordServiceFacade.deleteWord(WORD_ID)))
+                .isInstanceOf(DataAccessResourceFailureException.class);
+
+        assertAll(
+                () -> assertThat(wordRepository.existsBy(WORD_ID)).isTrue(),
+                () -> assertThat(wordExampleRepository.countBy(WORD_ID)).isEqualTo(WORD_EXAMPLE_COUNT),
+                () -> assertThat(pronunciationRepository.countBy(WORD_ID)).isEqualTo(PRONUNCIATION_COUNT),
+                () -> assertThat(deletedWordIdRepository.findAllBy(FAR_FUTURE)).isEmpty(),
+                () -> verify(deletedWordIdRepository).save(anyLong(), any(LocalDateTime.class))
+        );
+    }
+
+    @Test
+    @Sql(scripts = {
+            "classpath:sql/admin/word/word_metadata.sql",
+            "classpath:sql/admin/word/word.sql"
+    })
+    void 외부_트랜잭션이_없다면_용어_삭제_이벤트를_처리할_수_없다() {
+        // when & then
+        assertThatThrownBy(() -> applicationEventPublisher.publishEvent(new DeletedWordEvent(WORD_ID)))
+                .isInstanceOf(IllegalTransactionStateException.class);
+
+        assertAll(
+                () -> assertThat(wordRepository.existsBy(WORD_ID)).isTrue(),
+                () -> assertThat(wordExampleRepository.countBy(WORD_ID)).isEqualTo(WORD_EXAMPLE_COUNT),
+                () -> assertThat(pronunciationRepository.countBy(WORD_ID)).isEqualTo(PRONUNCIATION_COUNT),
+                () -> assertThat(deletedWordIdRepository.findAllBy(FAR_FUTURE)).isEmpty()
+        );
+    }
+}


### PR DESCRIPTION
## 📎 관련 Issue 번호
<!-- (필수) 해당 PR과 관련 있는 issue 번호를 입력해주세요. -->
- closed #137 
## 📄 작업 내용 요약
<!-- (필수) 작업한 내용을 간단히 요약해주세요. -->

용어 삭제 관련 이벤트 처리 방식을 테스트하는 케이스는 이미 존재했으나
엄밀히 따지면 해당 이벤트 리스너에 트랜잭션이 정확히 있는지 여부를 확인하는 정도의 테스트였습니다 

이는 기능을 확장했을 때 트랜잭션을 누락하는 경우 정상적으로 이를 캐치할 수 없으므로 
외부 트랜잭션의 유무 및 이벤트 처리 성공 / 실패에 따라 상태를 직접 확인하는 통합 테스트를 추가했습니다

## 🙋🏻 주의 깊게 확인해야 하는 코드
<!-- (선택) 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 📄 개선 사항 OR 참고 사항
<!-- (선택) 해당 PR에서 개선했거나, 참고 사항이 있다면 설명해주세요. -->